### PR TITLE
[feat] 낮 방 정보와 라운드 수를 전역 상태로 저장한다.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "react-cookie": "^7.1.4",
         "react-dom": "^18.2.0",
         "react-hot-toast": "^2.4.1",
-        "react-router-dom": "^6.22.3"
+        "react-router-dom": "^6.22.3",
+        "recoil": "^0.7.7"
       },
       "devDependencies": {
         "@types/react": "^18.2.66",
@@ -2421,6 +2422,11 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3079,6 +3085,25 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
+      "integrity": "sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/regenerator-runtime": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react-cookie": "^7.1.4",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.1",
-    "react-router-dom": "^6.22.3"
+    "react-router-dom": "^6.22.3",
+    "recoil": "^0.7.7"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/src/axios/http.ts
+++ b/src/axios/http.ts
@@ -1,4 +1,4 @@
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
+import { useSuspenseQuery } from '@tanstack/react-query'
 import { http } from './instances'
 import {
     Chat,
@@ -9,6 +9,7 @@ import {
     RoomRequest,
     RoomResponse,
     RoomStatusRequest,
+    RoomsStatus,
 } from '../type'
 
 export const useChatsQuery = () => {
@@ -36,12 +37,12 @@ export const useRoomsStatusQuery = () => {
 
 export const getRoomsStatus = () => {
     return http.get<RoomsStatus>('/rooms/status')
+}
 
 export const useRoomsInfoQuery = () => {
     const { data: roomInfo, ...rest } = useSuspenseQuery({
         queryKey: ['rooms', 'info', localStorage.getItem('auth')],
         queryFn: () => getRoomsInfo(),
-        refetchInterval: 1000,
     })
     return {
         roomInfo,
@@ -51,18 +52,25 @@ export const useRoomsInfoQuery = () => {
 
 export const getRoomsInfo = () => {
     // return http.get<RoomInfoResponse>(`/rooms/info`)
-    const mockPlayer: Player = {
-        name: '지윤짱짱맨',
-        isAlive: true,
-        role: 'mafia',
-    }
+    const mockPlayer: Player[] = [
+        {
+            name: '지윤짱짱맨',
+            isAlive: true,
+            role: 'mafia',
+        },
+        {
+            name: '재연짱짱맨',
+            isAlive: true,
+            role: 'citizen',
+        },
+    ]
     return {
         startTime: new Date(),
         endTime: new Date(),
-        alive: true,
+        isAlive: true,
         totalPlayers: 6,
         isMaster: true,
-        players: [mockPlayer],
+        players: mockPlayer,
     }
 }
 

--- a/src/axios/instances.ts
+++ b/src/axios/instances.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
 
 export const axiosInstance = axios.create({
-    baseURL: 'http://3.34.135.8:8080',
+    baseURL: 'https://mafia-together.com/api',
     withCredentials: true,
     timeout: 5000,
 })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,13 +2,16 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { RecoilRoot } from 'recoil'
 
 const queryClient = new QueryClient()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-        <QueryClientProvider client={queryClient}>
-            <App />
-        </QueryClientProvider>
+        <RecoilRoot>
+            <QueryClientProvider client={queryClient}>
+                <App />
+            </QueryClientProvider>
+        </RecoilRoot>
     </React.StrictMode>
 )

--- a/src/pages/InputName.tsx
+++ b/src/pages/InputName.tsx
@@ -10,7 +10,6 @@ import { participateRooms } from '../axios/http'
 import { Toaster } from 'react-hot-toast'
 import { notifyUseToast } from '../components/toast/NotifyToast'
 
-
 export default function InputName() {
     const middle = css`
         display: flex;
@@ -60,7 +59,7 @@ export default function InputName() {
             try {
                 const auth = await participateRooms({ code: code, name: name })
                 localStorage.setItem('auth', auth.auth)
-                navigate('/waiting')
+                navigate('/room')
             } catch (error: Error | any) {
                 notifyUseToast(error.message)
             }

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -1,12 +1,33 @@
-import React, { useState } from 'react'
 import WaitingRoom from './WaitingRoom'
 import Day from './Day'
 import Night from './Night'
 import Result from './Result'
-import { useRoomsStatusQuery } from '../axios/http'
+import { useRoomsInfoQuery, useRoomsStatusQuery } from '../axios/http'
+import { useRecoilState, useSetRecoilState } from 'recoil'
+import { gameRound, roomInfoState } from '../recoil/roominfo/atom'
+import { useEffect } from 'react'
 
 export default function Room() {
-    const roomsStatus = useRoomsStatusQuery()
+    // 방 상태 불러오기
+    let roomsStatus = useRoomsStatusQuery()
+    roomsStatus = 'DAY'
+
+    // 방 정보 저장 (방 상태가 바뀔때만 작동?)
+    const setRoomsInfoState = useSetRecoilState(roomInfoState)
+    const { roomInfo } = useRoomsInfoQuery()
+
+    useEffect(() => {
+        console.log('qkRNla')
+        setRoomsInfoState(roomInfo)
+    }, [roomInfo])
+
+    // DAY로 바뀔때 마다 라운드 +1
+    const [gameRoundState, setGameRoundState] = useRecoilState(gameRound)
+    useEffect(() => {
+        if (roomsStatus === 'DAY') {
+            setGameRoundState(gameRoundState + 1)
+        }
+    }, [roomsStatus])
 
     return (
         <>

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -16,7 +16,6 @@ export default function Room() {
     const { roomInfo } = useRoomsInfoQuery()
 
     useEffect(() => {
-        console.log('qkRNla')
         setRoomsInfoState(roomInfo)
     }, [roomInfo])
 

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -9,8 +9,7 @@ import { useEffect } from 'react'
 
 export default function Room() {
     // 방 상태 불러오기
-    let roomsStatus = useRoomsStatusQuery()
-    roomsStatus = 'DAY'
+    const roomsStatus = useRoomsStatusQuery()
 
     // 방 정보 저장 (방 상태가 바뀔때만 작동?)
     const setRoomsInfoState = useSetRecoilState(roomInfoState)

--- a/src/recoil/roominfo/atom.ts
+++ b/src/recoil/roominfo/atom.ts
@@ -1,0 +1,18 @@
+import { atom } from 'recoil'
+
+export const roomInfoState = atom({
+    key: 'roomInfo',
+    default: {
+        startTime: new Date(),
+        endTime: new Date(),
+        isAlive: true,
+        totalPlayers: 0,
+        isMaster: true,
+        players: [{}],
+    },
+})
+
+export const gameRound = atom({
+    key: 'gameRound',
+    default: 0,
+})


### PR DESCRIPTION
어떻게 해야할지 감이 안잡혀서 고민이 많았던 업무입니다. 막상 이리저리 해보니 코드가 몇줄안되네요. 저 좋은 코드가 있다면 편하게 말씀해주세요 :)

1. 방 정보(info)를 room 컴포넌트에서 받아서 전역으로 저장해줬어요. (recoil 썼습니다)
2. DAY가 될때마다 round +1 해주어써요. 이것도 마찬가지로 전역으로 저장해줬습니다.

방 정보 저장하는 행위는 방 상태가 바뀔때만 작동하도록 의도했는데, 이게 되는건지 안되는건지 확신이 없네요.. info api 완성되면 한번더 테스트해봐야될거같아요.


close #20 