### PR TITLE
[refactor] 채팅 프로필, 채팅 묶어서, 모바일크롬vh, 밤인트로를 수정한다.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,10 +12,12 @@ function App() {
     )
 }
 
+export default App
+
 function setScreenSize() {
     const vh = window.innerHeight * 0.01
     document.documentElement.style.setProperty('--vh', `${vh}px`)
 }
-setScreenSize()
 
-export default App
+setScreenSize()
+window.addEventListener('resize', setScreenSize)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,4 +12,10 @@ function App() {
     )
 }
 
+function setScreenSize() {
+    const vh = window.innerHeight * 0.01
+    document.documentElement.style.setProperty('--vh', `${vh}px`)
+}
+setScreenSize()
+
 export default App

--- a/src/axios/http.ts
+++ b/src/axios/http.ts
@@ -23,8 +23,8 @@ export const useChatsQuery = () => {
     const { data: chats, ...rest } = useSuspenseQuery({
         queryKey: ['chats', localStorage.getItem('auth')],
         queryFn: () => getChats(),
-        refetchInterval: 100,
-        staleTime: 100,
+        refetchInterval: 500,
+        staleTime: 500,
     })
     return {
         chats,

--- a/src/components/chat/ChatGroup.tsx
+++ b/src/components/chat/ChatGroup.tsx
@@ -4,6 +4,8 @@ import { VariablesCSS } from '../../styles/VariablesCSS'
 import PlayerChat from '../player/PlayerChat'
 import ChatMessage from './ChatMessage'
 import { forwardRef } from 'react'
+import { useRecoilState, useRecoilValue } from 'recoil'
+import { myJobState, roomInfoState } from '../../recoil/roominfo/atom'
 
 interface Props {
     name: string
@@ -38,9 +40,12 @@ export default forwardRef(function ChatGroup({ name, contents, isOwner }: Props,
         color: ${VariablesCSS.day};
     `
 
+    const myjob = useRecoilValue(myJobState)
+    const roomInfo = useRecoilValue(roomInfoState)
+
     return (
         <div ref={ref} css={container}>
-            <PlayerChat />
+            <PlayerChat job={roomInfo.myName == name ? myjob : null} />
             <div css={right}>
                 <p css={nameText}>{name}</p>
                 <ChatMessage contents={contents} isOwner={isOwner} />

--- a/src/components/chat/ChatGroup.tsx
+++ b/src/components/chat/ChatGroup.tsx
@@ -39,12 +39,9 @@ export default forwardRef(function ChatGroup({ chats }: Props, ref: any) {
         color: ${VariablesCSS.day};
     `
 
-    const myjob = useRecoilValue(myJobState)
-    const roomInfo = useRecoilValue(roomInfoState)
-
     return (
         <div ref={ref} css={container}>
-            <PlayerChat job={roomInfo.myName == chats[0].name ? myjob : null} />
+            <PlayerChat job={chats[0].job} />
             <div css={right}>
                 <p css={nameText}>{chats[0].name}</p>
                 {chats.map((chat) => (

--- a/src/components/chat/ChatGroup.tsx
+++ b/src/components/chat/ChatGroup.tsx
@@ -4,20 +4,19 @@ import { VariablesCSS } from '../../styles/VariablesCSS'
 import PlayerChat from '../player/PlayerChat'
 import ChatMessage from './ChatMessage'
 import { forwardRef } from 'react'
-import { useRecoilState, useRecoilValue } from 'recoil'
+import { useRecoilValue } from 'recoil'
 import { myJobState, roomInfoState } from '../../recoil/roominfo/atom'
+import { Chat } from '../../type'
 
 interface Props {
-    name: string
-    contents: string
-    isOwner: boolean
+    chats: Chat[]
 }
-export default forwardRef(function ChatGroup({ name, contents, isOwner }: Props, ref: any) {
+export default forwardRef(function ChatGroup({ chats }: Props, ref: any) {
     const container = css`
         display: flex;
         margin-bottom: 8px;
         gap: 8px;
-        ${isOwner && 'flex-direction: row-reverse;'}
+        ${chats[0].isOwner && 'flex-direction: row-reverse;'}
 
         &:first-of-type {
             margin-top: 20px;
@@ -30,7 +29,7 @@ export default forwardRef(function ChatGroup({ name, contents, isOwner }: Props,
         flex-direction: column;
         flex-grow: 0;
 
-        ${isOwner && 'align-items: end;'}
+        ${chats[0].isOwner && 'align-items: end;'}
     `
 
     const nameText = css`
@@ -45,10 +44,16 @@ export default forwardRef(function ChatGroup({ name, contents, isOwner }: Props,
 
     return (
         <div ref={ref} css={container}>
-            <PlayerChat job={roomInfo.myName == name ? myjob : null} />
+            <PlayerChat job={roomInfo.myName == chats[0].name ? myjob : null} />
             <div css={right}>
-                <p css={nameText}>{name}</p>
-                <ChatMessage contents={contents} isOwner={isOwner} />
+                <p css={nameText}>{chats[0].name}</p>
+                {chats.map((chat) => (
+                    <ChatMessage
+                        contents={chat.contents}
+                        isOwner={chat.isOwner}
+                        key={`${chat.timestamp}`}
+                    />
+                ))}
             </div>
         </div>
     )

--- a/src/components/chat/ChatGroup.tsx
+++ b/src/components/chat/ChatGroup.tsx
@@ -4,8 +4,6 @@ import { VariablesCSS } from '../../styles/VariablesCSS'
 import PlayerChat from '../player/PlayerChat'
 import ChatMessage from './ChatMessage'
 import { forwardRef } from 'react'
-import { useRecoilValue } from 'recoil'
-import { myJobState, roomInfoState } from '../../recoil/roominfo/atom'
 import { Chat } from '../../type'
 
 interface Props {

--- a/src/components/chat/Chats.tsx
+++ b/src/components/chat/Chats.tsx
@@ -12,24 +12,31 @@ export const Chats = () => {
         if (!chatRef.current) return
         chatRef.current.scrollIntoView()
     }, [chatRef, chats])
+
+    const chatReduce = chats.reduce(
+        (acc: [Chat[]], chat, index) => {
+            if (index > 0) {
+                if (chat.name === chats[index - 1].name) {
+                    acc[acc.length - 1].push(chat)
+                } else {
+                    acc.push([chat])
+                }
+                return acc
+            } else {
+                acc[0] = [chat]
+                return acc
+            }
+        },
+        [[]]
+    )
+
     return (
         <>
-            {chats.map((chat: Chat, idx: number) =>
+            {chatReduce.map((chats: Chat[], idx: number) =>
                 idx === chats.length - 1 ? (
-                    <ChatGroup
-                        ref={chatRef}
-                        key={idx}
-                        name={chat.name}
-                        contents={chat.contents}
-                        isOwner={chat.isOwner}
-                    />
+                    <ChatGroup ref={chatRef} key={idx} chats={chats} />
                 ) : (
-                    <ChatGroup
-                        key={idx}
-                        name={chat.name}
-                        contents={chat.contents}
-                        isOwner={chat.isOwner}
-                    />
+                    <ChatGroup key={idx} chats={chats} />
                 )
             )}
         </>

--- a/src/components/chat/Chats.tsx
+++ b/src/components/chat/Chats.tsx
@@ -32,13 +32,14 @@ export const Chats = () => {
 
     return (
         <>
-            {chatReduce.map((chats: Chat[], idx: number) =>
-                idx === chats.length - 1 ? (
-                    <ChatGroup ref={chatRef} key={idx} chats={chats} />
-                ) : (
-                    <ChatGroup key={idx} chats={chats} />
-                )
-            )}
+            {chatReduce[0].length > 0 &&
+                chatReduce.map((chats: Chat[], idx: number) =>
+                    idx === chats.length - 1 ? (
+                        <ChatGroup ref={chatRef} key={idx} chats={chats} />
+                    ) : (
+                        <ChatGroup key={idx} chats={chats} />
+                    )
+                )}
         </>
     )
 }

--- a/src/components/etc/Loading.tsx
+++ b/src/components/etc/Loading.tsx
@@ -1,3 +1,3 @@
 export const Loading = () => {
-    return <div>Loading</div>
+    return <div></div>
 }

--- a/src/components/layout/AppContainerCSS.tsx
+++ b/src/components/layout/AppContainerCSS.tsx
@@ -11,7 +11,7 @@ export default function AppContainerCSS({ background, children }: PropsType) {
     const container = css`
         max-width: 390px;
 
-        @media screen and (hover: none) and (pointer: coarse) {
+        @media (hover: none) and (pointer: coarse) {
             max-width: 100vw;
         }
         height: calc(var(--vh, 1vh) * 100);

--- a/src/components/layout/AppContainerCSS.tsx
+++ b/src/components/layout/AppContainerCSS.tsx
@@ -14,26 +14,23 @@ export default function AppContainerCSS({ background, children }: PropsType) {
         @media screen and (hover: none) and (pointer: coarse) {
             max-width: 100vw;
         }
-        height: 100vh;
+        height: calc(var(--vh, 1vh) * 100);
         margin: 0 auto;
         padding: 0;
         overflow: hidden;
 
-        background:
-            ${
-                background === 'day'
-                    ? 'linear-gradient(164.58deg, #a4c8ff 9.01%, #c5d1ff 53.87%, #ffdaca 91.32%);'
-                    : background === 'night'
-                      ? 'linear-gradient(167.95deg, #302e94 0%, #34073f 51%, #4f002f 100%);'
-                      : 'linear-gradient(167.95deg, #0300a0 0%, #622173 51%, #61023b 100%);'
-            }
-
         & > *:first-of-type {
             position: relative;
-            height: 100vh;
+            height: calc(var(--vh, 1vh) * 100);
             margin-left: ${VariablesCSS.margin};
             margin-right: ${VariablesCSS.margin};
         }
+
+        background: ${background === 'day'
+            ? 'linear-gradient(164.58deg, #a4c8ff 9.01%, #c5d1ff 53.87%, #ffdaca 91.32%);'
+            : background === 'night'
+              ? 'linear-gradient(167.95deg, #302e94 0%, #34073f 51%, #4f002f 100%);'
+              : 'linear-gradient(167.95deg, #0300a0 0%, #622173 51%, #61023b 100%);'};
     `
 
     return <div css={container}>{children}</div>

--- a/src/components/modal/ModalContainer.tsx
+++ b/src/components/modal/ModalContainer.tsx
@@ -35,7 +35,7 @@ export default function ModalContainer({ isOpen, openMotion = true, children }: 
         margin-left: -${VariablesCSS.margin};
         margin-right: -${VariablesCSS.margin};
         width: 100%;
-        height: 100vh;
+        height: calc(var(--vh, 1vh) * 100);
         background-color: rgba(0, 0, 0, 0.7);
     `
 

--- a/src/components/modal/VoteResult.tsx
+++ b/src/components/modal/VoteResult.tsx
@@ -13,8 +13,6 @@ export default function VoteResult() {
         ;(async () => {
             const deadResponse = await getVote()
             setDead(deadResponse.dead)
-            console.log(deadResponse)
-            console.log(dead)
         })()
     }, [])
 

--- a/src/components/player/PlayerChat.tsx
+++ b/src/components/player/PlayerChat.tsx
@@ -1,8 +1,13 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react'
 import JobIcon from '../svg/JobIcon'
+import { Job } from '../../type'
 
-export default function PlayerChat() {
+type PropsType = {
+    job: Job
+}
+
+export default function PlayerChat({ job }: PropsType) {
     const container = css`
         flex-shrink: 0;
         display: flex;
@@ -16,7 +21,7 @@ export default function PlayerChat() {
 
     return (
         <div css={container}>
-            <JobIcon size="small" color="day" />
+            <JobIcon size="small" color="day" job={job} />
         </div>
     )
 }

--- a/src/pages/CreateRoom.tsx
+++ b/src/pages/CreateRoom.tsx
@@ -13,7 +13,7 @@ import { createRoom } from '../axios/http'
 export function CreateRoom() {
     /* css */
     const middle = css`
-        height: calc(100vh - ${VariablesCSS.top} - ${VariablesCSS.bottombutton});
+        height: calc((var(--vh, 1vh) * 100) - ${VariablesCSS.top} - ${VariablesCSS.bottombutton});
         overflow: scroll;
         -ms-overflow-style: none;
         scrollbar-width: none;

--- a/src/pages/Day.tsx
+++ b/src/pages/Day.tsx
@@ -60,20 +60,7 @@ export default function Day({ statusType }: PropsType) {
     }
 
     /* 투표시간 */
-    const [voteState, setVoteStatus] = useState('')
     useEffect(() => {
-        if (statusType === 'VOTE') {
-            if (Math.trunc((+new Date(roomInfo.endTime) - +new Date()) / 1000) > 2) {
-                //모든 플레이어가 투표를 완료했음
-                setVoteStatus('voteAll')
-            } else {
-                //낮 시간이 끝났음
-                setVoteStatus('timeUp')
-            }
-        } else {
-            setVoteStatus('')
-        }
-
         // 공지 모달이 뜨는 시간엔 사용자가 켠 모달 끄기
         if (statusType !== 'DAY') {
             setOpenModal(false)
@@ -87,7 +74,7 @@ export default function Day({ statusType }: PropsType) {
                 {/* INTRO TIME */}
                 {statusType === 'DAY_INTRO' ? (
                     <>
-                        <p css={gameMessage}>낮이 되었습니다.</p>
+                        <p css={gameMessage}>낮이 되었습니다</p>
                     </>
                 ) : (
                     <div>
@@ -104,6 +91,17 @@ export default function Day({ statusType }: PropsType) {
                         {/* 살아있는 경우에만 input창이 보인다. */}
                         {isAlive && <ChatInput />}
 
+                        {/* 공지 모달 TIME*/}
+                        <ModalContainer isOpen={statusType === 'NOTICE'}>
+                            {gameRoundState === 1 ? (
+                                // 직업공지
+                                <NoticeMyJob name={roomInfo?.myName || ''} />
+                            ) : (
+                                // 전날밤 사망공지
+                                <NoticeDead></NoticeDead>
+                            )}
+                        </ModalContainer>
+
                         <ModalContainer isOpen={openModal}>
                             {isAlive ? (
                                 /* 투표모달 */
@@ -118,30 +116,10 @@ export default function Day({ statusType }: PropsType) {
                             )}
                         </ModalContainer>
 
-                        {/* 공지 모달 TIME*/}
-                        <ModalContainer isOpen={statusType === 'NOTICE'} openMotion={false}>
-                            {gameRoundState === 1 ? (
-                                // 직업공지
-                                <NoticeMyJob name={roomInfo?.myName || ''} />
-                            ) : (
-                                // 전날밤 사망공지
-                                <NoticeDead></NoticeDead>
-                            )}
-                        </ModalContainer>
-
-                        {/* 시간이 다 됨 */}
-                        <ModalContainer isOpen={voteState === 'timeUp' && roomInfo.isAlive}>
+                        {/* 투표시간이 되었을 때 */}
+                        <ModalContainer isOpen={statusType === 'VOTE' && roomInfo.isAlive}>
                             <Vote
-                                timeup={voteState === 'timeUp'}
-                                voteTarget={voteTarget}
-                                setVoteTarget={(number) => setVoteTarget(number)}
-                            />
-                        </ModalContainer>
-
-                        {/* 모두 투표함 */}
-                        <ModalContainer isOpen={voteState === 'voteAll' && roomInfo.isAlive}>
-                            <Vote
-                                voteAll={voteState === 'voteAll'}
+                                timeup={statusType === 'VOTE'}
                                 voteTarget={voteTarget}
                                 setVoteTarget={(number) => setVoteTarget(number)}
                             />

--- a/src/pages/FirstPage.tsx
+++ b/src/pages/FirstPage.tsx
@@ -10,7 +10,7 @@ export default function FirstPage() {
         display: flex;
         flex-direction: column;
         justify-content: space-evenly;
-        height: 100vh;
+        height: calc(var(--vh, 1vh) * 100);
 
         @keyframes slowshow {
             0% {
@@ -70,7 +70,7 @@ export default function FirstPage() {
         }
         & > p:nth-of-type(2) {
             animation: slowshow 2s 2.6s backwards ease-out;
-            margin-bottom: 8vh;
+            margin-bottom: calc(var(--vh, 1vh) * 8);
         }
         & > p:nth-of-type(3) {
             animation: slowshow 2s 3.4s backwards ease-out;

--- a/src/pages/InputCode.tsx
+++ b/src/pages/InputCode.tsx
@@ -11,7 +11,7 @@ import { Toaster } from 'react-hot-toast'
 export default function ParticipateRoom() {
     const middle = css`
         display: flex;
-        height: calc(100vh - ${VariablesCSS.top});
+        height: calc((var(--vh, 1vh) * 100) - ${VariablesCSS.top});
         flex-direction: column;
         justify-content: center;
         align-items: center;

--- a/src/pages/InputName.tsx
+++ b/src/pages/InputName.tsx
@@ -15,7 +15,7 @@ export default function InputName() {
         display: flex;
         justify-content: center;
         align-items: center;
-        height: calc(100vh - ${VariablesCSS.top} - ${VariablesCSS.bottombutton});
+        height: calc((var(--vh, 1vh) * 100) - ${VariablesCSS.top} - ${VariablesCSS.bottombutton});
     `
 
     const nameCss = css`

--- a/src/pages/Night.tsx
+++ b/src/pages/Night.tsx
@@ -1,15 +1,16 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react'
 import { VariablesCSS } from '../styles/VariablesCSS'
-import { useEffect, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import AppContainerCSS from '../components/layout/AppContainerCSS'
 import TopNight from '../components/top/TopNight'
 import { getMyJob, getRoomsInfo } from '../axios/http'
 import { MafiaNight } from '../components/job/MafiaNight'
-import { Job, RoomInfo } from '../type'
+import { Job, RoomInfo, Status } from '../type'
 import { PoliceNight } from '../components/job/PoliceNight'
 import { DoctorNight } from '../components/job/DoctorNight'
 import { CitizenNight } from '../components/job/CitizenNight'
+import { Loading } from '../components/etc/Loading'
 
 export const middle = css`
     height: calc(100% - ${VariablesCSS.top});
@@ -21,7 +22,22 @@ export const middle = css`
     }
 `
 
-export default function Night() {
+type PropsType = {
+    statusType: Status
+}
+
+export default function Night({ statusType }: PropsType) {
+    const gameMessage = css`
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: calc(100% - ${VariablesCSS.top});
+        font-family: 'Cafe24Ssurround', sans-serif;
+        font-size: 24px;
+        color: ${VariablesCSS.light};
+        animation: smoothshow 0.8s;
+    `
+
     const [roomInfo, setRoomInfo] = useState<RoomInfo>()
     const [myJob, setMyJob] = useState<Job | null>(null)
     useEffect(() => {
@@ -39,23 +55,46 @@ export default function Night() {
 
     return (
         <AppContainerCSS background="night">
-            <div>
-                <TopNight />
-                <div css={middle}>
-                    {'MAFIA' === myJob && (
-                        <MafiaNight players={roomInfo.players} isAlive={roomInfo.isAlive} />
-                    )}
-                    {'CITIZEN' === myJob && (
-                        <CitizenNight players={roomInfo.players} isAlive={roomInfo.isAlive} />
-                    )}
-                    {'POLICE' === myJob && (
-                        <PoliceNight players={roomInfo.players} isAlive={roomInfo.isAlive} />
-                    )}
-                    {'DOCTOR' === myJob && (
-                        <DoctorNight players={roomInfo.players} isAlive={roomInfo.isAlive} />
+            <Suspense fallback={<Loading />}>
+                <div>
+                    {/* INTRO TIME */}
+                    {statusType === 'NIGHT_INTRO' ? (
+                        <>
+                            <p css={gameMessage}>밤이 찾아왔습니다</p>
+                        </>
+                    ) : (
+                        <>
+                            <TopNight />
+                            <div css={middle}>
+                                {'MAFIA' === myJob && (
+                                    <MafiaNight
+                                        players={roomInfo.players}
+                                        isAlive={roomInfo.isAlive}
+                                    />
+                                )}
+                                {'CITIZEN' === myJob && (
+                                    <CitizenNight
+                                        players={roomInfo.players}
+                                        isAlive={roomInfo.isAlive}
+                                    />
+                                )}
+                                {'POLICE' === myJob && (
+                                    <PoliceNight
+                                        players={roomInfo.players}
+                                        isAlive={roomInfo.isAlive}
+                                    />
+                                )}
+                                {'DOCTOR' === myJob && (
+                                    <DoctorNight
+                                        players={roomInfo.players}
+                                        isAlive={roomInfo.isAlive}
+                                    />
+                                )}
+                            </div>
+                        </>
                     )}
                 </div>
-            </div>
+            </Suspense>
         </AppContainerCSS>
     )
 }

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -15,7 +15,7 @@ export default function Result() {
         flex-direction: column;
         justify-content: start;
         align-items: center;
-        height: calc(100vh - ${VariablesCSS.top} - ${VariablesCSS.bottombutton});
+        height: calc((var(--vh, 1vh) * 100) - ${VariablesCSS.top} - ${VariablesCSS.bottombutton});
         overflow: scroll;
         -ms-overflow-style: none;
         scrollbar-width: none;

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -40,8 +40,9 @@ export default function Room() {
                 roomsStatus.statusType === 'VOTE_RESULT') && (
                 <Day statusType={roomsStatus.statusType} />
             )}
-            {roomsStatus.statusType === 'NIGHT_INTRO' ||
-                (roomsStatus.statusType === 'NIGHT' && <Night />)}
+            {(roomsStatus.statusType === 'NIGHT_INTRO' || roomsStatus.statusType === 'NIGHT') && (
+                <Night statusType={roomsStatus.statusType} />
+            )}
             {roomsStatus.statusType === 'END' && <Result />}
         </>
     )

--- a/src/pages/WaitingRoom.tsx
+++ b/src/pages/WaitingRoom.tsx
@@ -18,7 +18,8 @@ export default function WaitingRoom() {
     /* css */
     const middle = css`
         height: calc(
-            100vh - ${VariablesCSS.top} - ${VariablesCSS.bigbutton} - ${VariablesCSS.margin}
+            (var(--vh, 1vh) * 100) - ${VariablesCSS.top} - ${VariablesCSS.bigbutton} -
+                ${VariablesCSS.margin}
         );
         overflow: scroll;
         -ms-overflow-style: none;
@@ -62,7 +63,7 @@ export default function WaitingRoom() {
         top: 0;
         left: 0;
         width: 100vw;
-        height: 100vh;
+        height: calc(var(--vh, 1vh) * 100);
         margin-left: -${VariablesCSS.margin};
         margin-right: -${VariablesCSS.margin};
         background-color: rgba(0, 0, 0, 0.7);

--- a/src/pages/WaitingRoom.tsx
+++ b/src/pages/WaitingRoom.tsx
@@ -168,9 +168,7 @@ export default function WaitingRoom() {
     const [openModal, setOpenModal] = useState(false)
     const onModal = () => {
         setOpenAnimation(true)
-        setTimeout(() => {
-            setOpenModal(true)
-        }, 450)
+        setOpenModal(true)
     }
 
     const onClose = () => {

--- a/src/styles/BaseCSS.ts
+++ b/src/styles/BaseCSS.ts
@@ -1,6 +1,11 @@
-import { VariablesCSS } from "./VariablesCSS";
+import { VariablesCSS } from './VariablesCSS'
 
 export const BaseCss = `
+    :root{
+        --vh: 100%;
+    }
+
+
     body,
     html,
     main,
@@ -153,4 +158,4 @@ export const BaseCss = `
     //         transform: translate(calc(-50% - ${VariablesCSS.margin}), calc(-50% + 5%));
     //     }
     // }
-`;
+`

--- a/src/styles/BaseCSS.ts
+++ b/src/styles/BaseCSS.ts
@@ -25,6 +25,7 @@ export const BaseCss = `
         border: none;
         background: none;
     }
+
     
     // 폰트
     @font-face {

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -22,6 +22,7 @@ export interface Chat {
     contents: string
     timestamp: Date
     isOwner: boolean
+    job: Job
 }
 
 export interface ChatRequest {


### PR DESCRIPTION
1. 채팅 Group안에서 위에 있는 사람의 이름을 알아내고 message만 보여주는 걸 생각했었는데요.
제 뇌피셜로는 css가 깨지고 복잡해질 것 같아서 아예 chats 자체를 재가공해서 보내는 걸로 해봤습니다.
아래처럼 배열로 한번더 감싸서, 같은 이름이라면 한 배열에 묶었어요.
더 좋은 방법이 있다면 편하게 말씀해주세요!

![chat설명](https://github.com/mafia-together/frontend/assets/70828192/7f16f3fa-d838-4a0b-a090-e7d0d81d22f2)


```
[
  [
    { 
      name: '이름',
      contents: '채팅 내용',
      timestamp: '2024-05-23T08:07L16.104+00:00'
      isOwner: true
      job: 'MAFIA'
    }, 
    { 
      name: '이름',
      contents: '채팅 내용',
      timestamp: '2024-05-23T08:07L16.104+00:00'
      isOwner: true
      job: 'MAFIA'
    }.
  ]
  [
    { 
      name: '이름2',
      contents: '채팅 내용',
      timestamp: '2024-05-23T08:07L16.104+00:00'
      isOwner: false
      job: null
    }.
  ]
]
```



2. 채팅 프로필에 볼 수 있는 직업 표시(본인과, 같은마피아)
원래 내 직업 비교하고 상대 마피아 이름뽑내었는데, api 바뀌어서 간단하게 job을 넘겨줬습니다!

3. 모바일 크롬에서 주소창때문에 밀려나는것때문에 css수정했는데, 배포 후 확인은 필요합니다!


close #54
close #33 