### PR TITLE
hotfix: 모바일 크롬에서 vh계산하는 방법을 초기와 resize될때를 구분한다.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,9 +15,14 @@ function App() {
 export default App
 
 function setScreenSize() {
+    const vh = window.innerHeight * 0.01
+    document.documentElement.style.setProperty('--vh', `${vh}px`)
+}
+
+function setScreenReSize() {
     const vh = visualViewport?.height ? visualViewport?.height * 0.01 : window.innerHeight * 0.01
     document.documentElement.style.setProperty('--vh', `${vh}px`)
 }
 
 setScreenSize()
-window.addEventListener('resize', setScreenSize)
+window.addEventListener('resize', setScreenReSize)


### PR DESCRIPTION
close #66 