### PR TITLE
refactor: emotion css 컴포넌트밖으로 빼기

### DIFF
--- a/src/components/button/BigButton.tsx
+++ b/src/components/button/BigButton.tsx
@@ -2,68 +2,71 @@
 import { css } from '@emotion/react'
 import { VariablesCSS } from '../../styles/VariablesCSS'
 
+const backgroundColor = {
+    emphasis: VariablesCSS.light90,
+    soft: VariablesCSS.light30,
+}
+
+const color = {
+    emphasis: VariablesCSS.night,
+    soft: VariablesCSS.light,
+}
+
+const icon = {
+    createRoom: '/assets/img/icon/create_room.svg',
+    participate: '/assets/img/icon/participate.svg',
+    gameStart: '/assets/img/icon/play.svg',
+}
+
+const text = {
+    createRoom: '방만들기',
+    participate: '참가하기',
+    gameStart: '게임시작',
+}
+
 type PropsType = {
     vatiety: 'emphasis' | 'soft'
     use: 'createRoom' | 'participate' | 'gameStart'
-    ready?: boolean
+    ready: boolean
 }
 
-export default function BigButton({ vatiety, use, ready = true }: PropsType) {
-    const backgroundColor = {
-        emphasis: VariablesCSS.light90,
-        soft: VariablesCSS.light30,
-    }
-
-    const color = {
-        emphasis: VariablesCSS.night,
-        soft: VariablesCSS.light,
-    }
-
-    const icon = {
-        createRoom: '/assets/img/icon/create_room.svg',
-        participate: '/assets/img/icon/participate.svg',
-        gameStart: '/assets/img/icon/play.svg',
-    }
-
-    const text = {
-        createRoom: '방만들기',
-        participate: '참가하기',
-        gameStart: '게임시작',
-    }
-
-    const button = css`
-        & > img {
-            display: block;
-        }
-
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        gap: 18px;
-        width: 100%;
-        height: ${VariablesCSS.bigbutton};
-        font-size: ${VariablesCSS.default};
-        font-family: 'Cafe24Ssurround', sans-serif;
-        border: 0;
-        border-radius: 15px;
-        box-shadow: inset -4px -4px 4px rgba(0, 0, 0, 0.25);
-        transition-property: box-shadow transform;
-        transition-duration: 0.1s;
-        cursor: pointer;
-        background-color: ${backgroundColor[vatiety]};
-        color: ${color[vatiety]};
-        ${ready ? 'opacity: 1' : 'opacity: 0.2'};
-
-        ${ready &&
-        `&:active {
-            box-shadow: inset -2px -2px 2px rgba(0, 0, 0, 0.25);
-            transform: translate(0.5px, 1px);`}
-    `
+export default function BigButton(props: PropsType) {
+    const { use } = props
 
     return (
-        <button css={button}>
-            <img src={icon[use]} draggable="false" />
+        <button css={container(props)}>
+            <img src={icon[use]} draggable="false" alt="" />
             <p>{text[use]}</p>
         </button>
     )
 }
+
+const container = (props: PropsType) => css`
+    & > img {
+        display: block;
+    }
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 18px;
+    width: 100%;
+    height: ${VariablesCSS.bigbutton};
+    font-size: ${VariablesCSS.default};
+    font-family: 'Cafe24Ssurround', sans-serif;
+    border: 0;
+    border-radius: 15px;
+    box-shadow: inset -4px -4px 4px rgba(0, 0, 0, 0.25);
+    transition-property: box-shadow transform;
+    transition-duration: 0.1s;
+    cursor: pointer;
+    background-color: ${backgroundColor[props.vatiety]};
+    color: ${color[props.vatiety]};
+    ${props.ready ? 'opacity: 1' : 'opacity: 0.2'};
+
+    ${props.ready &&
+    `&:active {
+        box-shadow: inset -2px -2px 2px rgba(0, 0, 0, 0.25);
+        transform: translate(0.5px, 1px);
+    }`}
+`

--- a/src/components/button/BottomButton.tsx
+++ b/src/components/button/BottomButton.tsx
@@ -4,51 +4,20 @@ import { VariablesCSS } from '../../styles/VariablesCSS'
 
 type PropsType = {
     use: 'complete' | 'exit'
-    daynight?: 'day' | 'night'
-    ready?: boolean
+    daynight: 'day' | 'night'
+    ready: boolean
 }
 
-export default function BottomButton({ use, daynight, ready = true }: PropsType) {
-    const text = {
-        complete: '완료',
-        exit: '대비방으로 나가기',
-    }
+const text = {
+    complete: '완료',
+    exit: '대비방으로 나가기',
+}
 
-    const container = css`
-        position: absolute;
-        bottom: 0;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        gap: 10px;
-        width: 100%;
-        height: ${VariablesCSS.bottombutton};
-        border-top: 1px solid ${VariablesCSS.light50};
-        color: ${VariablesCSS.light};
-        font-family: 'Cafe24Ssurround';
-        font-size: ${VariablesCSS.default};
-        box-sizing: border-box;
-        cursor: pointer;
-        ${ready
-            ? `
-            opacity: 1;
-            &:active * {
-            transform: translate(0.5px, 0.5px);
-        }`
-            : 'opacity: 0.2'};
-
-        & * {
-            transition: transform 0.1s;
-        }
-
-        ${daynight === 'day'
-            ? `border-top: 1px solid ${VariablesCSS.day50};
-        color: ${VariablesCSS.day};`
-            : ``}
-    `
+export default function BottomButton(props: PropsType) {
+    const { use } = props
 
     return (
-        <button css={container}>
+        <button css={container(props)}>
             {use === 'complete' && (
                 <svg
                     width="24"
@@ -64,7 +33,40 @@ export default function BottomButton({ use, daynight, ready = true }: PropsType)
                 </svg>
             )}
 
-            <p>{text[use]}</p>
+            <p>{text[props.use]}</p>
         </button>
     )
 }
+
+const container = (props: PropsType) => css`
+    position: absolute;
+    bottom: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    height: ${VariablesCSS.bottombutton};
+    border-top: 1px solid ${VariablesCSS.light50};
+    color: ${VariablesCSS.light};
+    font-family: 'Cafe24Ssurround';
+    font-size: ${VariablesCSS.default};
+    box-sizing: border-box;
+    cursor: pointer;
+    ${props.ready
+        ? `
+            opacity: 1;
+            &:active * {
+            transform: translate(0.5px, 0.5px);
+        }`
+        : 'opacity: 0.2'};
+
+    & * {
+        transition: transform 0.1s;
+    }
+
+    ${props.daynight === 'day'
+        ? `border-top: 1px solid ${VariablesCSS.day50};
+        color: ${VariablesCSS.day};`
+        : ``}
+`

--- a/src/components/button/CheckButton.tsx
+++ b/src/components/button/CheckButton.tsx
@@ -9,43 +9,8 @@ type PropsType = {
     onCountJob: (job: string, number: number) => void
 }
 
-export default function CheckButton({ job, count, onCountJob }: PropsType) {
-    const countGroup = css`
-        display: flex;
-        justify-content: space-between;
-        gap: 8px;
-        font-size: 40px;
-        font-variant-numeric: tabular-nums;
-        font-family: 'Cafe24Ssurround';
-        color: ${VariablesCSS.light};
-    `
-
-    const checkinput = css`
-        display: none;
-
-        & + label {
-            box-sizing: border-box;
-            position: relative;
-            width: 50px;
-            height: 50px;
-            border: 5px solid ${VariablesCSS.light};
-            border-radius: 15px;
-            background-color: ${VariablesCSS.light20};
-            transition: transform 0.1s;
-            cursor: pointer;
-        }
-
-        &:checked + label {
-            background-image: url(/assets/img/icon/check.svg);
-            background-color: ${VariablesCSS.light20};
-            background-repeat: no-repeat;
-            background-position: center;
-        }
-
-        &:active + label {
-            transform: translate(0.5px, 1px);
-        }
-    `
+export default function CheckButton(props: PropsType) {
+    const { job, count, onCountJob } = props
 
     /* 체크 */
     const onChecked = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -70,3 +35,40 @@ export default function CheckButton({ job, count, onCountJob }: PropsType) {
         </button>
     )
 }
+
+const countGroup = () => css`
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    font-size: 40px;
+    font-variant-numeric: tabular-nums;
+    font-family: 'Cafe24Ssurround';
+    color: ${VariablesCSS.light};
+`
+
+const checkinput = () => css`
+    display: none;
+
+    & + label {
+        box-sizing: border-box;
+        position: relative;
+        width: 50px;
+        height: 50px;
+        border: 5px solid ${VariablesCSS.light};
+        border-radius: 15px;
+        background-color: ${VariablesCSS.light20};
+        transition: transform 0.1s;
+        cursor: pointer;
+    }
+
+    &:checked + label {
+        background-image: url(/assets/img/icon/check.svg);
+        background-color: ${VariablesCSS.light20};
+        background-repeat: no-repeat;
+        background-position: center;
+    }
+
+    &:active + label {
+        transform: translate(0.5px, 1px);
+    }
+`

--- a/src/components/button/SmallButton.tsx
+++ b/src/components/button/SmallButton.tsx
@@ -7,32 +7,34 @@ type PropsType = {
     color: 'day' | 'night'
 }
 
-export default function SmallButton({ text, color }: PropsType) {
-    const container = css`
-        padding: 16px 30px;
-        font-family: 'Cafe24Ssurround', sans-serif;
-        font-size: 20px;
-        text-align: center;
-        border-radius: 15px;
-        box-shadow: inset -2px -2px 4px rgba(0, 0, 0, 0.25);
-        transition-property: box-shadow, transform, background-color, color;
-        transition-duration: 0.1s;
-        cursor: pointer;
-        ${color === 'day'
-            ? `color: ${VariablesCSS.day}; 
-        background-color: ${VariablesCSS.light30};`
-            : `color: ${VariablesCSS.light};
-        background-color: ${VariablesCSS.light20};`}
-
-        &:active {
-            box-shadow: inset -1px -1px 2px rgba(0, 0, 0, 0.25);
-            transform: translate(0.5px, 1px);
-        }
-    `
+export default function SmallButton(props: PropsType) {
+    const { text } = props
 
     return (
-        <button css={container}>
+        <button css={container(props)}>
             <p>{text}</p>
         </button>
     )
 }
+
+const container = (props: PropsType) => css`
+    padding: 16px 30px;
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 20px;
+    text-align: center;
+    border-radius: 15px;
+    box-shadow: inset -2px -2px 4px rgba(0, 0, 0, 0.25);
+    transition-property: box-shadow, transform, background-color, color;
+    transition-duration: 0.1s;
+    cursor: pointer;
+    ${props.color === 'day'
+        ? `color: ${VariablesCSS.day}; 
+        background-color: ${VariablesCSS.light30};`
+        : `color: ${VariablesCSS.light};
+        background-color: ${VariablesCSS.light20};`}
+
+    &:active {
+        box-shadow: inset -1px -1px 2px rgba(0, 0, 0, 0.25);
+        transform: translate(0.5px, 1px);
+    }
+`

--- a/src/components/chat/ChatGroup.tsx
+++ b/src/components/chat/ChatGroup.tsx
@@ -6,41 +6,16 @@ import ChatMessage from './ChatMessage'
 import { forwardRef } from 'react'
 import { Chat } from '../../type'
 
-interface Props {
+interface PropsType {
     chats: Chat[]
 }
-export default forwardRef(function ChatGroup({ chats }: Props, ref: any) {
-    const container = css`
-        display: flex;
-        margin-bottom: 8px;
-        gap: 8px;
-        ${chats[0].isOwner && 'flex-direction: row-reverse;'}
-
-        &:first-of-type {
-            margin-top: 20px;
-        }
-    `
-
-    const right = css`
-        display: flex;
-        align-items: start;
-        flex-direction: column;
-        flex-grow: 0;
-
-        ${chats[0].isOwner && 'align-items: end;'}
-    `
-
-    const nameText = css`
-        margin-bottom: 8px;
-        font-family: 'Cafe24Ssurround', sans-serif;
-        font-size: 14px;
-        color: ${VariablesCSS.day};
-    `
+export default forwardRef(function ChatGroup(props: PropsType, ref: any) {
+    const { chats } = props
 
     return (
-        <div ref={ref} css={container}>
+        <div ref={ref} css={container(props)}>
             <PlayerChat job={chats[0].job} />
-            <div css={right}>
+            <div css={right(props)}>
                 <p css={nameText}>{chats[0].name}</p>
                 {chats.map((chat) => (
                     <ChatMessage
@@ -53,3 +28,30 @@ export default forwardRef(function ChatGroup({ chats }: Props, ref: any) {
         </div>
     )
 })
+
+const container = (props: PropsType) => css`
+    display: flex;
+    margin-bottom: 8px;
+    gap: 8px;
+    ${props.chats[0].isOwner && 'flex-direction: row-reverse;'}
+
+    &:first-of-type {
+        margin-top: 20px;
+    }
+`
+
+const right = (props: PropsType) => css`
+    display: flex;
+    align-items: start;
+    flex-direction: column;
+    flex-grow: 0;
+
+    ${props.chats[0].isOwner && 'align-items: end;'}
+`
+
+const nameText = () => css`
+    margin-bottom: 8px;
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 14px;
+    color: ${VariablesCSS.day};
+`

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -10,41 +10,11 @@ function isInvalidInputChat(inputChat: string) {
 }
 
 export const ChatInput = () => {
-    const chatInput = css`
-        box-sizing: border-box;
-        flex-flow: 1;
-        width: 100%;
-        margin-right: 4px;
-        padding: 11px 20px;
-        font-size: 16px;
-        font-family: 'KCC-Hanbit', sans-serif;
-        color: ${VariablesCSS.day};
-        background-color: rgba(255, 255, 255, 0.2);
-        border: 3px solid #ffffff;
-        border-radius: 15px;
-
-        &::placeholder {
-            color: ${VariablesCSS.day30};
-        }
-
-        &:focus {
-            outline: 3px solid #ffffff;
-            background-color: rgba(255, 255, 255, 0.4);
-        }
-    `
     const [inputChat, setInputChat] = useState<string>('')
     return (
         <>
             <form
-                css={css`
-                    position: absolute;
-                    bottom: 17px;
-                    height: calc(55px + 17px);
-                    width: 100%;
-                    display: flex;
-                    justify-content: space-between;
-                    align-items: center;
-                `}
+                css={chatForm}
                 onSubmit={(event) => {
                     event.preventDefault()
                     postChats({ contents: inputChat })
@@ -65,17 +35,52 @@ export const ChatInput = () => {
                     type="submit"
                     value="전송"
                     disabled={isInvalidInputChat(inputChat)}
-                    css={css`
-                        font-family: 'Cafe24Ssurround', sans-serif;
-                        padding: 18px 14px;
-                        font-size: 16px;
-                        border-radius: 20px;
-                        ${isInvalidInputChat(inputChat) && 'opacity: 0.2;'}
-                        color: ${VariablesCSS.day};
-                        cursor: pointer;
-                    `}
+                    css={chatSubmit(inputChat)}
                 />
             </form>
         </>
     )
 }
+
+const chatForm = () => css`
+    position: absolute;
+    bottom: 17px;
+    height: calc(55px + 17px);
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+`
+
+const chatInput = () => css`
+    box-sizing: border-box;
+    flex-flow: 1;
+    width: 100%;
+    margin-right: 4px;
+    padding: 11px 20px;
+    font-size: 16px;
+    font-family: 'KCC-Hanbit', sans-serif;
+    color: ${VariablesCSS.day};
+    background-color: rgba(255, 255, 255, 0.2);
+    border: 3px solid #ffffff;
+    border-radius: 15px;
+
+    &::placeholder {
+        color: ${VariablesCSS.day30};
+    }
+
+    &:focus {
+        outline: 3px solid #ffffff;
+        background-color: rgba(255, 255, 255, 0.4);
+    }
+`
+
+const chatSubmit = (inputChat: string) => css`
+    font-family: 'Cafe24Ssurround', sans-serif;
+    padding: 18px 14px;
+    font-size: 16px;
+    border-radius: 20px;
+    ${isInvalidInputChat(inputChat) && 'opacity: 0.2;'}
+    color: ${VariablesCSS.day};
+    cursor: pointer;
+`

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -6,23 +6,19 @@ type PropsType = {
     contents: string
     isOwner: boolean
 }
-export default function ChatMessage({ contents, isOwner }: PropsType) {
-    return (
-        <p
-            css={css`
-                margin-bottom: 8px;
-                padding: 12px 20px;
-                ${isOwner
-                    ? 'border-radius: 15px 3px 15px 15px;'
-                    : 'border-radius: 3px 15px 15px 15px;'}
-                background-color: rgba(255, 255, 255, 0.8);
-                font-family: 'KCC-Hanbit', sans-serif;
-                color: ${VariablesCSS.day};
+export default function ChatMessage(props: PropsType) {
+    const { contents } = props
 
-                ${isOwner && 'align-items: end;'}
-            `}
-        >
-            {contents}
-        </p>
-    )
+    return <p css={message(props)}>{contents}</p>
 }
+
+const message = (props: PropsType) => css`
+    margin-bottom: 8px;
+    padding: 12px 20px;
+    ${props.isOwner ? 'border-radius: 15px 3px 15px 15px;' : 'border-radius: 3px 15px 15px 15px;'}
+    background-color: rgba(255, 255, 255, 0.8);
+    font-family: 'KCC-Hanbit', sans-serif;
+    color: ${VariablesCSS.day};
+
+    ${props.isOwner && 'align-items: end;'}
+`

--- a/src/components/etc/CountGroup.tsx
+++ b/src/components/etc/CountGroup.tsx
@@ -9,44 +9,8 @@ type PropsType = {
     onCountJob: (job: string, number: number) => void
 }
 
-export default function CountGroup({ job, count, onCountJob }: PropsType) {
-    const countGroup = css`
-        display: flex;
-        justify-content: space-between;
-        gap: 8px;
-        font-size: 40px;
-        font-variant-numeric: tabular-nums;
-        font-family: 'Cafe24Ssurround';
-        color: ${VariablesCSS.light};
-    `
-
-    const countLetterContainer = css`
-        display: flex;
-    `
-
-    const countletter = css`
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 30px;
-    `
-
-    const button = css`
-        width: 50px;
-        height: 50px;
-        background-color: ${VariablesCSS.light20};
-        border: 0;
-        border-radius: 15px;
-        box-shadow: inset -3px -2px 4px rgba(0, 0, 0, 0.25);
-        transition-property: box-shadow transform;
-        transition-duration: 0.1s;
-        cursor: pointer;
-
-        &:active {
-            transform: translate(0.5px, 1px);
-            box-shadow: inset -1.5px -1px 2px rgba(0, 0, 0, 0.25);
-        }
-    `
+export default function CountGroup(props: PropsType) {
+    const { job, count, onCountJob } = props
 
     const makeTwoWord = (number: number) => {
         if (number < 10) {
@@ -84,3 +48,41 @@ export default function CountGroup({ job, count, onCountJob }: PropsType) {
         </div>
     )
 }
+
+const countGroup = css`
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    font-size: 40px;
+    font-variant-numeric: tabular-nums;
+    font-family: 'Cafe24Ssurround';
+    color: ${VariablesCSS.light};
+`
+
+const countLetterContainer = css`
+    display: flex;
+`
+
+const countletter = css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+`
+
+const button = css`
+    width: 50px;
+    height: 50px;
+    background-color: ${VariablesCSS.light20};
+    border: 0;
+    border-radius: 15px;
+    box-shadow: inset -3px -2px 4px rgba(0, 0, 0, 0.25);
+    transition-property: box-shadow transform;
+    transition-duration: 0.1s;
+    cursor: pointer;
+
+    &:active {
+        transform: translate(0.5px, 1px);
+        box-shadow: inset -1.5px -1px 2px rgba(0, 0, 0, 0.25);
+    }
+`

--- a/src/components/etc/JobCount.tsx
+++ b/src/components/etc/JobCount.tsx
@@ -12,34 +12,14 @@ type PropsType = {
     onCountJob: (job: string, number: number) => void
 }
 
-export default function JobCount({ job, count, onCountJob }: PropsType) {
-    const jobName = {
-        MAFIA: '마피아',
-        DOCTOR: '의사',
-        POLICE: '경찰',
-    }
+const jobName = {
+    MAFIA: '마피아',
+    DOCTOR: '의사',
+    POLICE: '경찰',
+}
 
-    const jobCountContainer = css`
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        height: 60px;
-        margin-bottom: 16px;
-        color: ${VariablesCSS.light};
-        font-size: 28px;
-        font-family: 'Cafe24Ssurround';
-    `
-
-    const jobGroup = css`
-        display: flex;
-        gap: 16px;
-        color: ${VariablesCSS.light};
-    `
-
-    const jobText = css`
-        display: block;
-        padding-top: 5px;
-    `
+export default function JobCount(props: PropsType) {
+    const { job, count, onCountJob } = props
 
     return (
         <div css={jobCountContainer}>
@@ -55,3 +35,25 @@ export default function JobCount({ job, count, onCountJob }: PropsType) {
         </div>
     )
 }
+
+const jobCountContainer = css`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: 60px;
+    margin-bottom: 16px;
+    color: ${VariablesCSS.light};
+    font-size: 28px;
+    font-family: 'Cafe24Ssurround';
+`
+
+const jobGroup = css`
+    display: flex;
+    gap: 16px;
+    color: ${VariablesCSS.light};
+`
+
+const jobText = css`
+    display: block;
+    padding-top: 5px;
+`

--- a/src/components/job/CitizenNight.tsx
+++ b/src/components/job/CitizenNight.tsx
@@ -6,18 +6,13 @@ import PlayerGrid from '../player/PlayerGrid'
 import PlayerNight from '../player/PlayerNight'
 import { middle } from '../../pages/Night'
 
-interface Props {
+interface PropsType {
     isAlive: boolean
     players: Player[]
 }
-export const CitizenNight = ({ players, isAlive }: Props) => {
-    const description = css`
-        margin: 36px auto;
-        font-family: 'Cafe24Ssurround', sans-serif;
-        font-size: 18px;
-        text-align: center;
-        color: ${VariablesCSS.light};
-    `
+export const CitizenNight = (props: PropsType) => {
+    const { players, isAlive } = props
+
     return (
         <div css={middle}>
             <div css={description}>
@@ -31,3 +26,11 @@ export const CitizenNight = ({ players, isAlive }: Props) => {
         </div>
     )
 }
+
+const description = css`
+    margin: 36px auto;
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 18px;
+    text-align: center;
+    color: ${VariablesCSS.light};
+`

--- a/src/components/job/DoctorNight.tsx
+++ b/src/components/job/DoctorNight.tsx
@@ -8,18 +8,13 @@ import { useEffect, useState } from 'react'
 import { postSkill } from '../../axios/http'
 import { middle } from '../../pages/Night'
 
-interface Props {
+interface PropsType {
     isAlive: boolean
     players: Player[]
 }
-export const DoctorNight = ({ players, isAlive }: Props) => {
-    const description = css`
-        margin: 36px auto;
-        font-family: 'Cafe24Ssurround', sans-serif;
-        font-size: 18px;
-        text-align: center;
-        color: ${VariablesCSS.light};
-    `
+export const DoctorNight = (props: PropsType) => {
+    const { players, isAlive } = props
+
     const [check, setCheck] = useState<number>(-1)
     useEffect(() => {
         ;(async () => {
@@ -53,3 +48,11 @@ export const DoctorNight = ({ players, isAlive }: Props) => {
         </div>
     )
 }
+
+const description = css`
+    margin: 36px auto;
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 18px;
+    text-align: center;
+    color: ${VariablesCSS.light};
+`

--- a/src/components/job/MafiaNight.tsx
+++ b/src/components/job/MafiaNight.tsx
@@ -9,18 +9,13 @@ import { useEffect, useState } from 'react'
 import { postSkill, useMafiaVoteResultQuery } from '../../axios/http'
 import { middle } from '../../pages/Night'
 
-interface Props {
+interface PropsType {
     isAlive: boolean
     players: Player[]
 }
-export const MafiaNight = ({ players, isAlive }: Props) => {
-    const description = css`
-        margin: 36px auto;
-        font-family: 'Cafe24Ssurround', sans-serif;
-        font-size: 18px;
-        text-align: center;
-        color: ${VariablesCSS.light};
-    `
+export const MafiaNight = (props: PropsType) => {
+    const { players, isAlive } = props
+
     const { mafiaVoteResult } = useMafiaVoteResultQuery()
     let nowVoteResult = mafiaVoteResult.target === '' ? 0 : -1
     players.forEach((player, i) => {
@@ -70,26 +65,35 @@ export const MafiaNight = ({ players, isAlive }: Props) => {
                 type="radio"
                 name="vote"
                 id="0"
-                css={css`
-                    display: none;
-                    &:checked + label > div {
-                        color: ${VariablesCSS.light};
-                        background-color: ${VariablesCSS.kill};
-                    }
-                `}
+                css={notkill}
                 checked={nowVoteResult === 0}
                 onChange={() => isAlive && setCheck(0)}
             />
-            <label
-                htmlFor="0"
-                css={css`
-                    margin: 60px auto 16px;
-                    display: flex;
-                    justify-content: center;
-                `}
-            >
+            <label htmlFor="0" css={notkillLable}>
                 <SmallButton text="안죽이기" color="night" />
             </label>
         </div>
     )
 }
+
+const description = css`
+    margin: 36px auto;
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 18px;
+    text-align: center;
+    color: ${VariablesCSS.light};
+`
+
+const notkill = () => css`
+    display: none;
+    &:checked + label > div {
+        color: ${VariablesCSS.light};
+        background-color: ${VariablesCSS.kill};
+    }
+`
+
+const notkillLable = () => css`
+    margin: 60px auto 16px;
+    display: flex;
+    justify-content: center;
+`

--- a/src/components/job/PoliceNight.tsx
+++ b/src/components/job/PoliceNight.tsx
@@ -9,18 +9,13 @@ import { useEffect, useState } from 'react'
 import InvestResult from '../modal/InvestResult'
 import { middle } from '../../pages/Night'
 
-interface Props {
+interface PropsType {
     isAlive: boolean
     players: Player[]
 }
-export const PoliceNight = ({ players, isAlive }: Props) => {
-    const description = css`
-        margin: 36px auto;
-        font-family: 'Cafe24Ssurround', sans-serif;
-        font-size: 18px;
-        text-align: center;
-        color: ${VariablesCSS.light};
-    `
+export const PoliceNight = (props: PropsType) => {
+    const { players, isAlive } = props
+
     const [check, setCheck] = useState<number>(-1)
     const [openModal, setOpenModal] = useState<boolean>(false)
     useEffect(() => {
@@ -58,3 +53,11 @@ export const PoliceNight = ({ players, isAlive }: Props) => {
         </>
     )
 }
+
+const description = () => css`
+    margin: 36px auto;
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 18px;
+    text-align: center;
+    color: ${VariablesCSS.light};
+`

--- a/src/components/layout/AppContainerCSS.tsx
+++ b/src/components/layout/AppContainerCSS.tsx
@@ -7,31 +7,33 @@ type PropsType = {
     children: JSX.Element
 }
 
-export default function AppContainerCSS({ background, children }: PropsType) {
-    const container = css`
-        max-width: 390px;
+export default function AppContainerCSS(props: PropsType) {
+    const { children } = props
 
-        @media (pointer: coarse) {
-            max-width: 100vw;
-        }
-
-        height: calc(var(--vh, 1vh) * 100);
-        margin: 0 auto;
-        padding: 0;
-
-        & > *:first-of-type {
-            position: relative;
-            height: calc(var(--vh, 1vh) * 100);
-            margin-left: ${VariablesCSS.margin};
-            margin-right: ${VariablesCSS.margin};
-        }
-
-        background: ${background === 'day'
-            ? 'linear-gradient(164.58deg, #a4c8ff 9.01%, #c5d1ff 53.87%, #ffdaca 91.32%);'
-            : background === 'night'
-              ? 'linear-gradient(167.95deg, #302e94 0%, #34073f 51%, #4f002f 100%);'
-              : 'linear-gradient(167.95deg, #0300a0 0%, #622173 51%, #61023b 100%);'};
-    `
-
-    return <div css={container}>{children}</div>
+    return <div css={container(props)}>{children}</div>
 }
+
+const container = (props: PropsType) => css`
+    max-width: 390px;
+
+    @media (pointer: coarse) {
+        max-width: 100vw;
+    }
+
+    height: calc(var(--vh, 1vh) * 100);
+    margin: 0 auto;
+    padding: 0;
+
+    & > *:first-of-type {
+        position: relative;
+        height: calc(var(--vh, 1vh) * 100);
+        margin-left: ${VariablesCSS.margin};
+        margin-right: ${VariablesCSS.margin};
+    }
+
+    background: ${props.background === 'day'
+        ? 'linear-gradient(164.58deg, #a4c8ff 9.01%, #c5d1ff 53.87%, #ffdaca 91.32%);'
+        : props.background === 'night'
+          ? 'linear-gradient(167.95deg, #302e94 0%, #34073f 51%, #4f002f 100%);'
+          : 'linear-gradient(167.95deg, #0300a0 0%, #622173 51%, #61023b 100%);'};
+`

--- a/src/components/modal/InvestResult.tsx
+++ b/src/components/modal/InvestResult.tsx
@@ -6,42 +6,45 @@ import { useEffect, useState } from 'react'
 import { Job, SkillResponse } from '../../type'
 import { postSkill } from '../../axios/http'
 
-interface Props {
+interface PropsType {
     target: string
 }
-export default function InvestResult({ target }: Props) {
+export default function InvestResult(props: PropsType) {
+    const { target } = props
+
     const [jobResult, setJobResult] = useState<Job>('CITIZEN')
     useEffect(() => {
-        (async () => {
+        ;(async () => {
             const skillResponse: SkillResponse = await postSkill({ target: target })
             setJobResult(skillResponse.result)
         })()
     }, [target])
 
-    const container = css`
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        color: ${VariablesCSS.night};
-        gap: 50px;
-        height: 100%;
-    `
-    const description = css`
-        font-family: 'DNFForgedBlade', sans-serif;
-        font-weight: bold;
-        font-size: 26px;
-        text-align: center;
-
-        ${jobResult === 'MAFIA' && `text-decoration: underline;`}
-    `
-
     return (
         <div css={container}>
             <PlayerInvest job={jobResult} name={target} />
-            <p css={description}>
+            <p css={description(jobResult)}>
                 {jobResult === 'MAFIA' ? '마피아가 맞습니다' : '마피아가 아닙니다'}
             </p>
         </div>
     )
 }
+
+const container = () => css`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    color: ${VariablesCSS.night};
+    gap: 50px;
+    height: 100%;
+`
+
+const description = (jobResult: Job) => css`
+    font-family: 'DNFForgedBlade', sans-serif;
+    font-weight: bold;
+    font-size: 26px;
+    text-align: center;
+
+    ${jobResult === 'MAFIA' && `text-decoration: underline;`}
+`

--- a/src/components/modal/ModalContainer.tsx
+++ b/src/components/modal/ModalContainer.tsx
@@ -5,11 +5,11 @@ import { useEffect, useState } from 'react'
 
 type PropsType = {
     isOpen: boolean
-    openMotion?: boolean
     children: JSX.Element
 }
 
-export default function ModalContainer({ isOpen, openMotion = true, children }: PropsType) {
+export default function ModalContainer(props: PropsType) {
+    const { isOpen, children } = props
     const [isOpened, setIsOpened] = useState(isOpen)
 
     useEffect(() => {
@@ -22,46 +22,46 @@ export default function ModalContainer({ isOpen, openMotion = true, children }: 
         }
     }, [isOpen])
 
-    const modal = css`
-        position: absolute;
-        width: calc(100% + ${VariablesCSS.margin} + ${VariablesCSS.margin});
-        left: 0;
-        top: 0;
-        ${openMotion && isOpen && 'animation: smoothshow 0.5s backwards;'}
-        ${isOpen || 'animation: smoothhide 0.5s backwards;'}
-    `
-
-    const dimmed = css`
-        margin-left: -${VariablesCSS.margin};
-        margin-right: -${VariablesCSS.margin};
-        width: 100%;
-        height: calc(var(--vh, 1vh) * 100);
-        background-color: rgba(0, 0, 0, 0.7);
-    `
-
-    const container = css`
-        overflow: hidden;
-        position: absolute;
-        left: 50%;
-        top: 50%;
-        width: 92%;
-        height: 70%;
-        background-color: #ffffff;
-        background: linear-gradient(152.82deg, #fbf1ff 0%, #fbf1ff 0%, #dae0ea 0.01%, #ddd5dd 100%);
-        border: 5px solid #ffffff;
-        box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.25);
-        border-radius: 15px;
-        transform: translate(calc(-50% - ${VariablesCSS.margin}), -50%);
-        ${openMotion && isOpen && 'animation: smoothup 0.5s backwards;'}
-        ${isOpen || 'animation: smoothdown 0.5s backwards;'}
-    `
-
     return (
         isOpened && (
-            <div css={modal}>
+            <div css={modal(props)}>
                 <div css={dimmed}></div>
-                <div css={container}>{children}</div>
+                <div css={container(props)}>{children}</div>
             </div>
         )
     )
 }
+
+const modal = (props: PropsType) => css`
+    position: absolute;
+    width: calc(100% + ${VariablesCSS.margin} + ${VariablesCSS.margin});
+    left: 0;
+    top: 0;
+    ${props.isOpen && 'animation: smoothshow 0.5s backwards;'}
+    ${props.isOpen || 'animation: smoothhide 0.5s backwards;'}
+`
+
+const dimmed = () => css`
+    margin-left: -${VariablesCSS.margin};
+    margin-right: -${VariablesCSS.margin};
+    width: 100%;
+    height: calc(var(--vh, 1vh) * 100);
+    background-color: rgba(0, 0, 0, 0.7);
+`
+
+const container = (props: PropsType) => css`
+    overflow: hidden;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 92%;
+    height: 70%;
+    background-color: #ffffff;
+    background: linear-gradient(152.82deg, #fbf1ff 0%, #fbf1ff 0%, #dae0ea 0.01%, #ddd5dd 100%);
+    border: 5px solid #ffffff;
+    box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.25);
+    border-radius: 15px;
+    transform: translate(calc(-50% - ${VariablesCSS.margin}), -50%);
+    ${props.isOpen && 'animation: smoothup 0.5s backwards;'}
+    ${props.isOpen || 'animation: smoothdown 0.5s backwards;'}
+`

--- a/src/components/modal/NoticeDead.tsx
+++ b/src/components/modal/NoticeDead.tsx
@@ -2,9 +2,11 @@
 import { css } from '@emotion/react'
 import { VariablesCSS } from '../../styles/VariablesCSS'
 import PlayerBig from '../player/PlayerBig'
-import { Dead } from '../../type'
+import { Color, Dead } from '../../type'
 import { useEffect, useState } from 'react'
 import { getRoomNightResultDead } from '../../axios/http'
+
+const color = (dead: Dead) => (dead ? 'kill' : 'safe')
 
 export default function NoticeDead() {
     // 전날밤
@@ -16,30 +18,12 @@ export default function NoticeDead() {
         })()
     }, [])
 
-    const color = dead ? 'kill' : 'safe'
-    const container = css`
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        color: ${VariablesCSS[color]};
-        gap: 50px;
-        height: 100%;
-    `
-
-    const description = css`
-        font-family: 'DNFForgedBlade', sans-serif;
-        font-weight: bold;
-        font-size: 26px;
-        text-align: center;
-    `
-
     return (
-        <div css={container}>
+        <div css={container(color(dead))}>
             {dead ? (
                 // 누눈가가 죽었음
                 <>
-                    <PlayerBig color={color} job="CITIZEN" name={dead} />
+                    <PlayerBig color={color(dead)} job="CITIZEN" name={dead} />
                     <p css={description}>
                         어젯밤 <br />
                         사망했습니다.
@@ -70,3 +54,20 @@ export default function NoticeDead() {
         </div>
     )
 }
+
+const container = (color: Color) => css`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    color: ${VariablesCSS[color]};
+    gap: 50px;
+    height: 100%;
+`
+
+const description = css`
+    font-family: 'DNFForgedBlade', sans-serif;
+    font-weight: bold;
+    font-size: 26px;
+    text-align: center;
+`

--- a/src/components/modal/NoticeMyJob.tsx
+++ b/src/components/modal/NoticeMyJob.tsx
@@ -12,32 +12,17 @@ type PropsType = {
     name: string
 }
 
-export default function NoticeMyJob({ name }: PropsType) {
-    const container = css`
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        color: ${VariablesCSS.day};
-        gap: 50px;
-        height: 100%;
-    `
-    const description = css`
-        font-family: 'DNFForgedBlade', sans-serif;
-        font-weight: bold;
-        font-size: 26px;
-        text-align: center;
-    `
+const text = {
+    CITIZEN: '시민',
+    MAFIA: '마피아',
+    DOCTOR: '의사',
+    POLICE: '경찰',
+}
 
-    const text = {
-        CITIZEN: '시민',
-        MAFIA: '마피아',
-        DOCTOR: '의사',
-        POLICE: '경찰',
-    }
+export default function NoticeMyJob(props: PropsType) {
+    const { name } = props
 
     // 내 직업공지
-
     const [myJob, setMyJob] = useState<Job>('CITIZEN')
     const setMyJobRecoilState = useSetRecoilState(myJobState) // 방 정보
     useEffect(() => {
@@ -58,3 +43,19 @@ export default function NoticeMyJob({ name }: PropsType) {
         </div>
     )
 }
+
+const container = css`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    color: ${VariablesCSS.day};
+    gap: 50px;
+    height: 100%;
+`
+const description = css`
+    font-family: 'DNFForgedBlade', sans-serif;
+    font-weight: bold;
+    font-size: 26px;
+    text-align: center;
+`

--- a/src/components/modal/ViewJob.tsx
+++ b/src/components/modal/ViewJob.tsx
@@ -9,55 +9,11 @@ import { TimeOnlySeconds } from '../time/TimeOnlySeconds'
 
 type PropsType = {
     onOpenModal?: () => void
-    voteTime?: boolean
+    voteTime: boolean
 }
 
-export default function ViewJob({ onOpenModal, voteTime }: PropsType) {
-    const top = css`
-        position: absolute;
-        top: 0;
-        width: 100%;
-        margin-top: 12px;
-    `
-
-    const title = css`
-        text-align: center;
-        font-size: ${VariablesCSS.title};
-        font-family: 'Cafe24Ssurround', sans-serif;
-        color: ${VariablesCSS.day};
-    `
-
-    const close = css`
-        position: absolute;
-        top: -6px;
-        right: 4px;
-        cursor: pointer;
-    `
-
-    const content = css`
-        height: calc(100% - 70px - ${VariablesCSS.margin});
-        margin-top: 70px;
-        margin-bottom: ${VariablesCSS.margin};
-        overflow: scroll;
-        -ms-overflow-style: none;
-        scrollbar-width: none;
-        &::-webkit-scrollbar {
-            display: none;
-        }
-    `
-
-    const description = css`
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        padding: 14px;
-        margin-bottom: 10px;
-        font-family: 'Cafe24Ssurround', sans-serif;
-        font-size: 16px;
-        color: ${VariablesCSS.day};
-        text-align: center;
-        opacity: 0.8;
-    `
+export default function ViewJob(props: PropsType) {
+    const { onOpenModal, voteTime } = props
 
     // 방정보 - 참가목록 받아오기
     const [roominfo] = useRecoilState(roomInfoState)
@@ -101,3 +57,49 @@ export default function ViewJob({ onOpenModal, voteTime }: PropsType) {
         </>
     )
 }
+
+const top = css`
+    position: absolute;
+    top: 0;
+    width: 100%;
+    margin-top: 12px;
+`
+
+const title = css`
+    text-align: center;
+    font-size: ${VariablesCSS.title};
+    font-family: 'Cafe24Ssurround', sans-serif;
+    color: ${VariablesCSS.day};
+`
+
+const close = css`
+    position: absolute;
+    top: -6px;
+    right: 4px;
+    cursor: pointer;
+`
+
+const content = css`
+    height: calc(100% - 70px - ${VariablesCSS.margin});
+    margin-top: 70px;
+    margin-bottom: ${VariablesCSS.margin};
+    overflow: scroll;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+        display: none;
+    }
+`
+
+const description = css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 14px;
+    margin-bottom: 10px;
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 16px;
+    color: ${VariablesCSS.day};
+    text-align: center;
+    opacity: 0.8;
+`

--- a/src/components/modal/Vote.tsx
+++ b/src/components/modal/Vote.tsx
@@ -17,70 +17,8 @@ type PropsType = {
     setVoteTarget: (number: number) => void
 }
 
-export default function Vote({
-    onOpenModal,
-    timeup,
-    voteAll,
-    voteTarget,
-    setVoteTarget,
-}: PropsType) {
-    const top = css`
-        position: absolute;
-        top: 0;
-        width: 100%;
-        margin-top: 12px;
-    `
-
-    const timeText = css`
-        text-align: center;
-        font-size: ${VariablesCSS.title};
-        font-family: 'Cafe24Ssurround', sans-serif;
-        color: ${VariablesCSS.day};
-    `
-
-    const close = css`
-        position: absolute;
-        top: -6px;
-        right: 4px;
-        cursor: pointer;
-    `
-
-    const content = css`
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-        height: calc(100% - 70px - ${VariablesCSS.margin});
-        margin-top: 70px;
-        margin-bottom: ${VariablesCSS.margin};
-        overflow: scroll;
-        -ms-overflow-style: none;
-        scrollbar-width: none;
-        &::-webkit-scrollbar {
-            display: none;
-        }
-    `
-
-    const description = css`
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        padding: 14px;
-        margin-bottom: 10px;
-        font-family: 'Cafe24Ssurround', sans-serif;
-        font-size: 16px;
-        color: ${VariablesCSS.day};
-        text-align: center;
-        opacity: 0.8;
-    `
-
-    const message = css`
-        margin-bottom: 30px;
-        font-family: 'DNFForgedBlade', sans-serif;
-        font-weight: 400;
-        font-size: 12px;
-        text-align: center;
-        color: ${VariablesCSS.day50};
-    `
+export default function Vote(props: PropsType) {
+    const { onOpenModal, timeup, voteAll, voteTarget, setVoteTarget } = props
 
     /* 방 정보 - 참가목록 받아오기 */
     const [roominfo] = useRecoilState(roomInfoState)
@@ -160,23 +98,10 @@ export default function Vote({
                         name="vote"
                         id="0"
                         checked={voteTarget === ABSTAIN_NUMBER}
-                        css={css`
-                            display: none;
-                            &:checked + label > div {
-                                color: ${VariablesCSS.light};
-                                background-color: ${VariablesCSS.kill};
-                            }
-                        `}
+                        css={abstention}
                         onChange={() => setVote(ABSTAIN_NUMBER, ABSTAIN_STRING)}
                     />
-                    <label
-                        htmlFor="0"
-                        css={css`
-                            margin: 30px auto 16px;
-                            display: flex;
-                            justify-content: center;
-                        `}
-                    >
+                    <label htmlFor="0" css={abstentionLabel}>
                         <SmallButton text="기권" color="day" />
                     </label>
                     {timeup || voteAll || (
@@ -187,3 +112,75 @@ export default function Vote({
         </>
     )
 }
+
+const top = () => css`
+    position: absolute;
+    top: 0;
+    width: 100%;
+    margin-top: 12px;
+`
+
+const timeText = () => css`
+    text-align: center;
+    font-size: ${VariablesCSS.title};
+    font-family: 'Cafe24Ssurround', sans-serif;
+    color: ${VariablesCSS.day};
+`
+
+const close = () => css`
+    position: absolute;
+    top: -6px;
+    right: 4px;
+    cursor: pointer;
+`
+
+const content = () => css`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: calc(100% - 70px - ${VariablesCSS.margin});
+    margin-top: 70px;
+    margin-bottom: ${VariablesCSS.margin};
+    overflow: scroll;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+        display: none;
+    }
+`
+
+const description = () => css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 14px;
+    margin-bottom: 10px;
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 16px;
+    color: ${VariablesCSS.day};
+    text-align: center;
+    opacity: 0.8;
+`
+
+const message = () => css`
+    margin-bottom: 30px;
+    font-family: 'DNFForgedBlade', sans-serif;
+    font-weight: 400;
+    font-size: 12px;
+    text-align: center;
+    color: ${VariablesCSS.day50};
+`
+
+const abstention = () => css`
+    display: none;
+    &:checked + label > div {
+        color: ${VariablesCSS.light};
+        background-color: ${VariablesCSS.kill};
+    }
+`
+
+const abstentionLabel = () => css`
+    margin: 30px auto 16px;
+    display: flex;
+    justify-content: center;
+`

--- a/src/components/modal/VoteResult.tsx
+++ b/src/components/modal/VoteResult.tsx
@@ -4,7 +4,9 @@ import { VariablesCSS } from '../../styles/VariablesCSS'
 import PlayerBig from '../player/PlayerBig'
 import { getVote } from '../../axios/http'
 import { useEffect, useState } from 'react'
-import { Dead } from '../../type'
+import { Color, Dead } from '../../type'
+
+const color = (dead: Dead) => (dead ? 'kill' : 'safe')
 
 export default function VoteResult() {
     const [dead, setDead] = useState<Dead>(null)
@@ -16,30 +18,12 @@ export default function VoteResult() {
         })()
     }, [])
 
-    const color = dead ? 'kill' : 'safe'
-
-    const container = css`
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        color: ${VariablesCSS[color]};
-        gap: 50px;
-        height: 100%;
-    `
-
-    const description = css`
-        font-family: 'DNFForgedBlade', sans-serif;
-        font-weight: bold;
-        font-size: 26px;
-        text-align: center;
-    `
     return (
-        <div css={container}>
+        <div css={container(color(dead))}>
             {dead ? (
                 // 누눈가가 죽었음
                 <>
-                    <PlayerBig color={color} job="CITIZEN" name={dead} />
+                    <PlayerBig color={color(dead)} job="CITIZEN" name={dead} />
                     <p css={description}>
                         플레이어가
                         <br />
@@ -59,3 +43,20 @@ export default function VoteResult() {
         </div>
     )
 }
+
+const container = (color: Color) => css`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    color: ${VariablesCSS[color]};
+    gap: 50px;
+    height: 100%;
+`
+
+const description = () => css`
+    font-family: 'DNFForgedBlade', sans-serif;
+    font-weight: bold;
+    font-size: 26px;
+    text-align: center;
+`

--- a/src/components/player/PlayerBig.tsx
+++ b/src/components/player/PlayerBig.tsx
@@ -10,30 +10,32 @@ type PropsType = {
     name: string
 }
 
-export default function PlayerBig({ color, job, name }: PropsType) {
+export default function PlayerBig(props: PropsType) {
+    const { job, name } = props
+
     return (
-        <div
-            css={css`
-                box-sizing: border-box;
-                display: flex;
-                flex-direction: column;
-                justify-content: center;
-                align-items: center;
-                gap: 20px;
-                width: 220px;
-                height: 220px;
-                padding: 10px 60px;
-                border-radius: 15px;
-                background-color: ${VariablesCSS.white30};
-                color: ${VariablesCSS[color]};
-                font-family: 'Cafe24Ssurround', sans-serif;
-                font-size: 20px;
-                text-align: center;
-                word-break: break-all;
-            `}
-        >
+        <div css={contianer(props)}>
             <JobIcon job={job} size="big" />
             <p>{name}</p>
         </div>
     )
 }
+
+const contianer = (props: PropsType) => css`
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 20px;
+    width: 220px;
+    height: 220px;
+    padding: 10px 60px;
+    border-radius: 15px;
+    background-color: ${VariablesCSS.white30};
+    color: ${VariablesCSS[props.color]};
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 20px;
+    text-align: center;
+    word-break: break-all;
+`

--- a/src/components/player/PlayerChat.tsx
+++ b/src/components/player/PlayerChat.tsx
@@ -8,18 +8,8 @@ type PropsType = {
     job: Job
 }
 
-export default function PlayerChat({ job }: PropsType) {
-    const container = css`
-        flex-shrink: 0;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        width: 40px;
-        height: 40px;
-        background-color: rgba(255, 255, 255, 0.7);
-        border-radius: 100%;
-        color: ${VariablesCSS.day};
-    `
+export default function PlayerChat(props: PropsType) {
+    const { job } = props
 
     return (
         <div css={container}>
@@ -27,3 +17,15 @@ export default function PlayerChat({ job }: PropsType) {
         </div>
     )
 }
+
+const container = css`
+    flex-shrink: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 40px;
+    height: 40px;
+    background-color: rgba(255, 255, 255, 0.7);
+    border-radius: 100%;
+    color: ${VariablesCSS.day};
+`

--- a/src/components/player/PlayerGrid.tsx
+++ b/src/components/player/PlayerGrid.tsx
@@ -4,16 +4,18 @@ import { css } from '@emotion/react'
 type PropsType = {
     children: JSX.Element[]
 }
-export default function PlayerGrid({ children }: PropsType) {
-    const grid = css`
-        display: grid;
-
-        justify-content: center;
-        gap: 8px;
-        grid-template-columns: repeat(auto-fill, 102px);
-
-        user-select: none;
-    `
+export default function PlayerGrid(props: PropsType) {
+    const { children } = props
 
     return <div css={grid}>{children}</div>
 }
+
+const grid = css`
+    display: grid;
+
+    justify-content: center;
+    gap: 8px;
+    grid-template-columns: repeat(auto-fill, 102px);
+
+    user-select: none;
+`

--- a/src/components/player/PlayerInvest.tsx
+++ b/src/components/player/PlayerInvest.tsx
@@ -9,29 +9,31 @@ type PropsType = {
     name: string
 }
 
-export default function PlayerInvest({ job, name }: PropsType) {
+export default function PlayerInvest(props: PropsType) {
+    const { job, name } = props
+
     return (
-        <div
-            css={css`
-                box-sizing: border-box;
-                display: flex;
-                flex-direction: column;
-                justify-content: center;
-                align-items: center;
-                gap: 20px;
-                width: 220px;
-                height: 220px;
-                padding: 10px 60px;
-                border-radius: 15px;
-                background-color: ${VariablesCSS.light15};
-                color: ${VariablesCSS.night};
-                font-family: 'Cafe24Ssurround', sans-serif;
-                font-size: 20px;
-                text-align: center;
-            `}
-        >
+        <div css={container}>
             <JobIcon job={job} size="big" />
             <p>{name}</p>
         </div>
     )
 }
+
+const container = () => css`
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 20px;
+    width: 220px;
+    height: 220px;
+    padding: 10px 60px;
+    border-radius: 15px;
+    background-color: ${VariablesCSS.light15};
+    color: ${VariablesCSS.night};
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 20px;
+    text-align: center;
+`

--- a/src/components/player/PlayerJob.tsx
+++ b/src/components/player/PlayerJob.tsx
@@ -8,39 +8,41 @@ type PropsType = {
     player: Player
 }
 
-export default function PlayerJob({ player }: PropsType) {
-    const container = css`
-        box-sizing: border-box;
-        display: flex;
-        flex-direction: column;
-        justify-content: start;
-        align-items: center;
-        gap: 8px;
-        width: 102px;
-        height: 102px;
-        padding: 11px 14px;
-        color: ${VariablesCSS.day};
-        font-family: 'Cafe24Ssurround', sans-serif;
-        font-size: 14px;
-        text-align: center;
-        background-color: ${VariablesCSS.white30};
-        border-radius: 15px;
-
-        & p {
-            display: flex;
-            align-items: center;
-            flex: 1;
-        }
-
-        ${!player.isAlive &&
-        `color: ${VariablesCSS.deadDay};
-        background: none;`}
-    `
+export default function PlayerJob(props: PropsType) {
+    const { player } = props
 
     return (
-        <div css={container}>
+        <div css={container(props)}>
             <JobIcon job={player.job} size="default" />
             <p>{player.name}</p>
         </div>
     )
 }
+
+const container = (props: PropsType) => css`
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: start;
+    align-items: center;
+    gap: 8px;
+    width: 102px;
+    height: 102px;
+    padding: 11px 14px;
+    color: ${VariablesCSS.day};
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 14px;
+    text-align: center;
+    background-color: ${VariablesCSS.white30};
+    border-radius: 15px;
+
+    & p {
+        display: flex;
+        align-items: center;
+        flex: 1;
+    }
+
+    ${!props.player.isAlive &&
+    `color: ${VariablesCSS.deadDay};
+    background: none;`}
+`

--- a/src/components/player/PlayerNight.tsx
+++ b/src/components/player/PlayerNight.tsx
@@ -12,89 +12,27 @@ type PropsType = {
     setCheck?: (check: number) => void
 }
 
-export default function PlayerNight({ player, index, myJob, nowVoteResult, setCheck }: PropsType) {
-    const backgounrdColor = {
-        CITIZEN: VariablesCSS.light30,
-        MAFIA: VariablesCSS.kill,
-        DOCTOR: 'rgba(241,249,255,0.8)',
-        POLICE: 'rgba(233,246,255,0.8)',
-    }
+const backgounrdColor = {
+    CITIZEN: VariablesCSS.light30,
+    MAFIA: VariablesCSS.kill,
+    DOCTOR: 'rgba(241,249,255,0.8)',
+    POLICE: 'rgba(233,246,255,0.8)',
+}
 
-    const color = {
-        CITIZEN: VariablesCSS.light,
-        MAFIA: VariablesCSS.light,
-        DOCTOR: VariablesCSS.night,
-        POLICE: VariablesCSS.night,
-    }
+const color = {
+    CITIZEN: VariablesCSS.light,
+    MAFIA: VariablesCSS.light,
+    DOCTOR: VariablesCSS.night,
+    POLICE: VariablesCSS.night,
+}
 
-    const inputCss = css`
-        display: none;
-
-        &:checked + label {
-            background-color: ${myJob && backgounrdColor[myJob]};
-
-            & svg {
-                color: ${myJob && color[myJob]};
-            }
-
-            & p {
-                color: ${myJob && color[myJob]};
-            }
-        }
-    `
-
-    const label = css`
-        & > div {
-            box-sizing: border-box;
-            display: flex;
-            flex-direction: column;
-            justify-content: start;
-            align-items: center;
-            gap: 8px;
-            width: 102px;
-            height: 102px;
-            padding: 11px 14px;
-        }
-
-        color: ${VariablesCSS.light};
-        font-family: 'Cafe24Ssurround', sans-serif;
-        font-size: 14px;
-        text-align: center;
-        background-color: ${VariablesCSS.light30};
-        border-radius: 15px;
-        box-shadow: inset -2px -2px 4px rgba(0, 0, 0, 0.25);
-        transition-property: box-shadow, transform, background-color, color;
-        transition-duration: 0.1s;
-        cursor: pointer;
-
-        &:active {
-            box-shadow: inset -1px -1px 2px rgba(0, 0, 0, 0.25);
-            transform: translate(0.5px, 1px);
-        }
-
-        ${player.isAlive ||
-        `color: rgba(158,137,178, 0.5);
-                background: none;
-                box-shadow: none;
-                cursor: auto;
-                
-            &:active {
-                box-shadow: none;
-                transform: none;
-            }
-            `}
-    `
-
-    const p = css`
-        display: flex;
-        align-items: center;
-        flex: 1;
-    `
+export default function PlayerNight(props: PropsType) {
+    const { player, index, nowVoteResult, setCheck } = props
 
     return (
         <>
             <input
-                css={inputCss}
+                css={inputCss(props)}
                 type="radio"
                 name="vote"
                 id={'' + index}
@@ -104,7 +42,7 @@ export default function PlayerNight({ player, index, myJob, nowVoteResult, setCh
                 }}
                 disabled={!player.isAlive}
             />
-            <label htmlFor={'' + index} css={label}>
+            <label htmlFor={'' + index} css={label(props)}>
                 <div>
                     <JobIcon job={player.job} size="default" />
                     <p css={p}>{player.name}</p>
@@ -113,3 +51,67 @@ export default function PlayerNight({ player, index, myJob, nowVoteResult, setCh
         </>
     )
 }
+
+const inputCss = (props: PropsType) => css`
+    display: none;
+
+    &:checked + label {
+        background-color: ${props.myJob && backgounrdColor[props.myJob]};
+
+        & svg {
+            color: ${props.myJob && color[props.myJob]};
+        }
+
+        & p {
+            color: ${props.myJob && color[props.myJob]};
+        }
+    }
+`
+
+const label = (props: PropsType) => css`
+    & > div {
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        justify-content: start;
+        align-items: center;
+        gap: 8px;
+        width: 102px;
+        height: 102px;
+        padding: 11px 14px;
+    }
+
+    color: ${VariablesCSS.light};
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 14px;
+    text-align: center;
+    background-color: ${VariablesCSS.light30};
+    border-radius: 15px;
+    box-shadow: inset -2px -2px 4px rgba(0, 0, 0, 0.25);
+    transition-property: box-shadow, transform, background-color, color;
+    transition-duration: 0.1s;
+    cursor: pointer;
+
+    &:active {
+        box-shadow: inset -1px -1px 2px rgba(0, 0, 0, 0.25);
+        transform: translate(0.5px, 1px);
+    }
+
+    ${props.player.isAlive ||
+    `color: rgba(158,137,178, 0.5);
+        background: none;
+        box-shadow: none;
+        cursor: auto;
+        
+    &:active {
+        box-shadow: none;
+        transform: none;
+    }
+    `}
+`
+
+const p = css`
+    display: flex;
+    align-items: center;
+    flex: 1;
+`

--- a/src/components/player/PlayerResult.tsx
+++ b/src/components/player/PlayerResult.tsx
@@ -9,39 +9,41 @@ type PropsType = {
     player: { name: string; isAlive: boolean; job: Job }
 }
 
-export default function PlayerResult({ victory, player }: PropsType) {
-    const container = css`
-        box-sizing: border-box;
-        display: flex;
-        flex-direction: column;
-        justify-content: start;
-        align-items: center;
-        gap: 8px;
-        width: 102px;
-        height: 102px;
-        padding: 11px 14px;
-        font-family: 'Cafe24Ssurround', sans-serif;
-        font-size: 14px;
-        text-align: center;
-        border-radius: 15px;
-
-        & p {
-            display: flex;
-            align-items: center;
-            flex: 1;
-        }
-
-        ${victory === 'MAFIA'
-            ? `color: ${VariablesCSS.light};
-    background-color: rgba(255, 255, 255, 0.12);`
-            : ` color: ${VariablesCSS.day};
-    background-color: rgba(255, 255, 255, 0.3);`}
-    `
+export default function PlayerResult(props: PropsType) {
+    const { player } = props
 
     return (
-        <div css={container}>
+        <div css={container(props)}>
             <JobIcon job={player.job} size="default" />
             <p>{player.name}</p>
         </div>
     )
 }
+
+const container = (props: PropsType) => css`
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: start;
+    align-items: center;
+    gap: 8px;
+    width: 102px;
+    height: 102px;
+    padding: 11px 14px;
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 14px;
+    text-align: center;
+    border-radius: 15px;
+
+    & p {
+        display: flex;
+        align-items: center;
+        flex: 1;
+    }
+
+    ${props.victory === 'MAFIA'
+        ? `color: ${VariablesCSS.light};
+        background-color: rgba(255, 255, 255, 0.12);`
+        : ` color: ${VariablesCSS.day};
+        background-color: rgba(255, 255, 255, 0.3);`}
+`

--- a/src/components/player/PlayerVote.tsx
+++ b/src/components/player/PlayerVote.tsx
@@ -11,70 +11,8 @@ type PropsType = {
     setVoteTarget: (number: number, name: string) => void
 }
 
-export default function PlayerVote({ player, index, voteTarget, setVoteTarget }: PropsType) {
-    const inputCss = css`
-        display: none;
-
-        &:checked + label {
-            background-color: ${VariablesCSS.kill};
-
-            & svg {
-                color: ${VariablesCSS.light};
-            }
-
-            & p {
-                color: ${VariablesCSS.light};
-            }
-        }
-    `
-
-    const label = css`
-        & > div {
-            box-sizing: border-box;
-            display: flex;
-            flex-direction: column;
-            justify-content: start;
-            align-items: center;
-            gap: 8px;
-            width: 102px;
-            height: 102px;
-            padding: 11px 14px;
-        }
-
-        color: ${VariablesCSS.day};
-        font-family: 'Cafe24Ssurround', sans-serif;
-        font-size: 14px;
-        text-align: center;
-        background-color: ${VariablesCSS.light30};
-        border-radius: 15px;
-        box-shadow: inset -2px -2px 4px rgba(0, 0, 0, 0.25);
-        transition-property: box-shadow, transform, background-color, color;
-        transition-duration: 0.1s;
-        cursor: pointer;
-
-        & p {
-            display: flex;
-            align-items: center;
-            flex: 1;
-        }
-
-        &:active {
-            box-shadow: inset -1px -1px 2px rgba(0, 0, 0, 0.25);
-            transform: translate(0.5px, 1px);
-        }
-
-        ${player.isAlive ||
-        `color: ${VariablesCSS.deadDay};
-                    background: none;
-                    box-shadow: none;
-                    cursor: auto;
-                    
-                &:active {
-                    box-shadow: none;
-                    transform: none;
-                }
-                `}
-    `
+export default function PlayerVote(props: PropsType) {
+    const { player, index, voteTarget, setVoteTarget } = props
 
     return (
         <>
@@ -87,7 +25,7 @@ export default function PlayerVote({ player, index, voteTarget, setVoteTarget }:
                 onChange={() => setVoteTarget(index, player.name)}
                 disabled={!player.isAlive}
             />
-            <label htmlFor={'' + index} css={label}>
+            <label htmlFor={'' + index} css={label(props)}>
                 <div>
                     <JobIcon job={player.job} size="default" />
                     <p>{player.name}</p>
@@ -96,3 +34,67 @@ export default function PlayerVote({ player, index, voteTarget, setVoteTarget }:
         </>
     )
 }
+
+const inputCss = () => css`
+    display: none;
+
+    &:checked + label {
+        background-color: ${VariablesCSS.kill};
+
+        & svg {
+            color: ${VariablesCSS.light};
+        }
+
+        & p {
+            color: ${VariablesCSS.light};
+        }
+    }
+`
+
+const label = (props: PropsType) => css`
+    & > div {
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        justify-content: start;
+        align-items: center;
+        gap: 8px;
+        width: 102px;
+        height: 102px;
+        padding: 11px 14px;
+    }
+
+    color: ${VariablesCSS.day};
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 14px;
+    text-align: center;
+    background-color: ${VariablesCSS.light30};
+    border-radius: 15px;
+    box-shadow: inset -2px -2px 4px rgba(0, 0, 0, 0.25);
+    transition-property: box-shadow, transform, background-color, color;
+    transition-duration: 0.1s;
+    cursor: pointer;
+
+    & p {
+        display: flex;
+        align-items: center;
+        flex: 1;
+    }
+
+    &:active {
+        box-shadow: inset -1px -1px 2px rgba(0, 0, 0, 0.25);
+        transform: translate(0.5px, 1px);
+    }
+
+    ${props.player.isAlive ||
+    `color: ${VariablesCSS.deadDay};
+            background: none;
+            box-shadow: none;
+            cursor: auto;
+            
+        &:active {
+            box-shadow: none;
+            transform: none;
+        }
+        `}
+`

--- a/src/components/player/PlayerWaiting.tsx
+++ b/src/components/player/PlayerWaiting.tsx
@@ -1,35 +1,12 @@
 /** @jsxImportSource @emotion/react */
-import { css } from "@emotion/react";
-import { VariablesCSS } from "../../styles/VariablesCSS";
+import { css } from '@emotion/react'
+import { VariablesCSS } from '../../styles/VariablesCSS'
 
 type PropsType = {
-    name: string;
-};
-export default function PlayerWaiting({ name }: PropsType) {
-    const container = css`
-        box-sizing: border-box;
-        display: flex;
-        flex-direction: column;
-        justify-content: start;
-        align-items: center;
-        gap: 8px;
-        width: 102px;
-        height: 102px;
-        padding: 11px 14px;
-        color: ${VariablesCSS.light};
-        font-family: "Cafe24Ssurround", sans-serif;
-        font-size: 14px;
-        text-align: center;
-        background-color: ${VariablesCSS.light15};
-        border-radius: 15px;
-    `;
-
-    const p = css`
-        display: flex;
-        align-items: center;
-        flex: 1;
-        word-break: break-all;
-    `;
+    name: string
+}
+export default function PlayerWaiting(props: PropsType) {
+    const { name } = props
 
     return (
         <div css={container}>
@@ -53,5 +30,30 @@ export default function PlayerWaiting({ name }: PropsType) {
                 <div></div>
             )}
         </div>
-    );
+    )
 }
+
+const container = () => css`
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: start;
+    align-items: center;
+    gap: 8px;
+    width: 102px;
+    height: 102px;
+    padding: 11px 14px;
+    color: ${VariablesCSS.light};
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 14px;
+    text-align: center;
+    background-color: ${VariablesCSS.light15};
+    border-radius: 15px;
+`
+
+const p = css`
+    display: flex;
+    align-items: center;
+    flex: 1;
+    word-break: break-all;
+`

--- a/src/components/svg/JobIcon.tsx
+++ b/src/components/svg/JobIcon.tsx
@@ -5,12 +5,14 @@ type PropsType = {
     size: 'small' | 'default' | 'big'
 }
 
-export default function JobIcon({ job, size }: PropsType) {
-    const sizeNumber = {
-        small: '20',
-        default: '40',
-        big: '80',
-    }
+const sizeNumber = {
+    small: '20',
+    default: '40',
+    big: '80',
+}
+
+export default function JobIcon(props: PropsType) {
+    const { job, size } = props
 
     switch (job) {
         case 'MAFIA':

--- a/src/components/time/Time.tsx
+++ b/src/components/time/Time.tsx
@@ -9,10 +9,6 @@ export const Time = () => {
         const lastMinutes = `${Math.trunc(lastTime / 60)}`
         const lastSecond = `${Math.trunc(lastTime % 60)}`.padStart(2, '0')
 
-        // if (+lastMinutes <= 0) {
-        //     lastMinutes = '0'
-        // }
-
         return [lastMinutes, lastSecond]
     }
 

--- a/src/components/top/TopDay.tsx
+++ b/src/components/top/TopDay.tsx
@@ -10,47 +10,8 @@ type PropsType = {
     statusType: Status
 }
 
-export default function TopDay({ isAlive, onOpenModal, statusType }: PropsType) {
-    const container = css`
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        height: ${VariablesCSS.top};
-        border-bottom: 1px solid ${VariablesCSS.day30};
-        font-size: ${VariablesCSS.title};
-        color: ${VariablesCSS.day};
-    `
-
-    const dayLeft = css`
-        display: flex;
-        align-items: center;
-        width: 85px;
-        gap: 8px;
-        font-family: 'WAGURITTF', sans-serif;
-    `
-
-    const dayText = css`
-        margin-top: 3px;
-        display: block;
-    `
-
-    const timeText = css`
-        padding-top: 2px;
-        font-family: 'Cafe24Ssurround', sans-serif;
-    `
-
-    const dayRight = css`
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        gap: 4px;
-        width: 85px;
-        font-family: 'Cafe24Ssurround', sans-serif;
-        font-size: 12px;
-        color: ${VariablesCSS.day};
-        cursor: pointer;
-    `
+export default function TopDay(props: PropsType) {
+    const { isAlive, onOpenModal, statusType } = props
 
     return (
         <div css={container}>
@@ -74,3 +35,44 @@ export default function TopDay({ isAlive, onOpenModal, statusType }: PropsType) 
         </div>
     )
 }
+
+const container = () => css`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: ${VariablesCSS.top};
+    border-bottom: 1px solid ${VariablesCSS.day30};
+    font-size: ${VariablesCSS.title};
+    color: ${VariablesCSS.day};
+`
+
+const dayLeft = () => css`
+    display: flex;
+    align-items: center;
+    width: 85px;
+    gap: 8px;
+    font-family: 'WAGURITTF', sans-serif;
+`
+
+const dayText = () => css`
+    margin-top: 3px;
+    display: block;
+`
+
+const timeText = () => css`
+    padding-top: 2px;
+    font-family: 'Cafe24Ssurround', sans-serif;
+`
+
+const dayRight = () => css`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+    width: 85px;
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 12px;
+    color: ${VariablesCSS.day};
+    cursor: pointer;
+`

--- a/src/components/top/TopEnter.tsx
+++ b/src/components/top/TopEnter.tsx
@@ -8,47 +8,21 @@ type PropsType = {
     onModal?: () => void
 }
 
-export default function TopEnter({ use, onModal }: PropsType) {
-    const title = {
-        createRoom: '방만들기',
-        participateRoom: '초대코드 입력',
-        inputName: '이름입력',
-        waitingRoom: '대기방',
-    }
+const title = {
+    createRoom: '방만들기',
+    participateRoom: '초대코드 입력',
+    inputName: '이름입력',
+    waitingRoom: '대기방',
+}
 
-    const topEnter = css`
-        position: relative;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        height: ${VariablesCSS.top};
-        border-bottom: 1px solid ${VariablesCSS.light50};
-        color: ${VariablesCSS.light};
-        font-family: 'WAGURITTF', sans-serif;
-        font-size: ${VariablesCSS.title};
-    `
-
-    const invite = css`
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-
-        border: none;
-        background: none;
-        color: ${VariablesCSS.light};
-        font-family: 'Cafe24Ssurround', sans-serif;
-        font-size: 14px;
-        cursor: pointer;
-    `
+export default function TopEnter(props: PropsType) {
+    const { use, onModal } = props
 
     /* 뒤로가기 */
     const navigate = useNavigate()
     const onBack = () => {
         navigate(-1)
     }
-
-    /* 초대하기 모달 */
 
     return (
         <div css={topEnter}>
@@ -74,3 +48,29 @@ export default function TopEnter({ use, onModal }: PropsType) {
         </div>
     )
 }
+
+const topEnter = () => css`
+    position: relative;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: ${VariablesCSS.top};
+    border-bottom: 1px solid ${VariablesCSS.light50};
+    color: ${VariablesCSS.light};
+    font-family: 'WAGURITTF', sans-serif;
+    font-size: ${VariablesCSS.title};
+`
+
+const invite = () => css`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+
+    border: none;
+    background: none;
+    color: ${VariablesCSS.light};
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 14px;
+    cursor: pointer;
+`

--- a/src/components/top/TopNight.tsx
+++ b/src/components/top/TopNight.tsx
@@ -4,32 +4,6 @@ import { VariablesCSS } from '../../styles/VariablesCSS'
 import { Time } from '../time/Time'
 
 export default function TopNight() {
-    const container = css`
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        height: ${VariablesCSS.top};
-        border-bottom: 1px solid ${VariablesCSS.light50};
-        font-size: ${VariablesCSS.title};
-        color: ${VariablesCSS.light};
-
-        & p {
-            margin-top: 2px;
-            display: block;
-        }
-    `
-
-    const left = css`
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        font-family: 'WAGURITTF', sans-serif;
-    `
-
-    const timeText = css`
-        padding-top: 2px;
-        font-family: 'Cafe24Ssurround', sans-serif;
-    `
     return (
         <div css={container}>
             <div css={left}>
@@ -42,3 +16,30 @@ export default function TopNight() {
         </div>
     )
 }
+
+const container = () => css`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: ${VariablesCSS.top};
+    border-bottom: 1px solid ${VariablesCSS.light50};
+    font-size: ${VariablesCSS.title};
+    color: ${VariablesCSS.light};
+
+    & p {
+        margin-top: 2px;
+        display: block;
+    }
+`
+
+const left = () => css`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: 'WAGURITTF', sans-serif;
+`
+
+const timeText = () => css`
+    padding-top: 2px;
+    font-family: 'Cafe24Ssurround', sans-serif;
+`

--- a/src/components/top/TopResult.tsx
+++ b/src/components/top/TopResult.tsx
@@ -7,38 +7,9 @@ type PropsType = {
     daynight: 'day' | 'night'
 }
 
-export default function TopResult({ daynight }: PropsType) {
-    const container = css`
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        height: ${VariablesCSS.top};
-        ${daynight === 'night'
-            ? `border-bottom: 1px solid ${VariablesCSS.light50};`
-            : `border-bottom: 1px solid ${VariablesCSS.day};`}
-
-        font-size: ${VariablesCSS.title};
-        ${daynight === 'night' ? `color: ${VariablesCSS.light};` : ` color: ${VariablesCSS.day};`}
-
-        & p {
-            margin-top: 2px;
-            display: block;
-        }
-    `
-    const left = css`
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        font-family: 'WAGURITTF', sans-serif;
-    `
-
-    const timeText = css`
-        padding-top: 2px;
-        font-family: 'Cafe24Ssurround', sans-serif;
-    `
-
+export default function TopResult(props: PropsType) {
     return (
-        <div css={container}>
+        <div css={container(props)}>
             <p css={left}>결과</p>
             <p css={timeText}>
                 <Time />
@@ -46,3 +17,32 @@ export default function TopResult({ daynight }: PropsType) {
         </div>
     )
 }
+
+const container = (props: PropsType) => css`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: ${VariablesCSS.top};
+    ${props.daynight === 'night'
+        ? `border-bottom: 1px solid ${VariablesCSS.light50};`
+        : `border-bottom: 1px solid ${VariablesCSS.day};`}
+
+    font-size: ${VariablesCSS.title};
+    ${props.daynight === 'night' ? `color: ${VariablesCSS.light};` : ` color: ${VariablesCSS.day};`}
+
+    & p {
+        margin-top: 2px;
+        display: block;
+    }
+`
+const left = () => css`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: 'WAGURITTF', sans-serif;
+`
+
+const timeText = () => css`
+    padding-top: 2px;
+    font-family: 'Cafe24Ssurround', sans-serif;
+`

--- a/src/pages/CreateRoom.tsx
+++ b/src/pages/CreateRoom.tsx
@@ -11,38 +11,6 @@ import BottomButton from '../components/button/BottomButton'
 import { createRoom } from '../axios/http'
 
 export function CreateRoom() {
-    /* css */
-    const middle = css`
-        height: calc((var(--vh, 1vh) * 100) - ${VariablesCSS.top} - ${VariablesCSS.bottombutton});
-        overflow: scroll;
-        -ms-overflow-style: none;
-        scrollbar-width: none;
-        &::-webkit-scrollbar {
-            display: none;
-        }
-    `
-
-    const totalCount = css`
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 16px;
-        width: 100%;
-        margin-top: 34px;
-        margin-bottom: 64px;
-        font-family: 'Cafe24Ssurround';
-        color: ${VariablesCSS.light};
-    `
-
-    const iconGroup = css`
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 4px;
-        margin: 0 auto;
-        font-size: 28px;
-    `
-
     /* data */
     const [jobCount, setjobCount] = useState({
         total: 0,
@@ -115,9 +83,40 @@ export function CreateRoom() {
                     <JobCount job="POLICE" count={jobCount.police} onCountJob={onCountjob} />
                 </div>
                 <div onClick={onCreateRoom}>
-                    <BottomButton use="complete" ready={canCreateRoom()} />
+                    <BottomButton use="complete" daynight="night" ready={canCreateRoom()} />
                 </div>
             </div>
         </AppContainerCSS>
     )
 }
+
+const middle = () => css`
+    height: calc((var(--vh, 1vh) * 100) - ${VariablesCSS.top} - ${VariablesCSS.bottombutton});
+    overflow: scroll;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+        display: none;
+    }
+`
+
+const totalCount = () => css`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    width: 100%;
+    margin-top: 34px;
+    margin-bottom: 64px;
+    font-family: 'Cafe24Ssurround';
+    color: ${VariablesCSS.light};
+`
+
+const iconGroup = () => css`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    margin: 0 auto;
+    font-size: 28px;
+`

--- a/src/pages/Day.tsx
+++ b/src/pages/Day.tsx
@@ -22,27 +22,6 @@ type PropsType = {
 }
 
 export default function Day({ statusType }: PropsType) {
-    const gameMessage = css`
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        height: calc(100% - ${VariablesCSS.top});
-        font-family: 'Cafe24Ssurround', sans-serif;
-        font-size: 24px;
-        color: ${VariablesCSS.day};
-        animation: smoothshow 0.8s;
-    `
-
-    const middle = css`
-        height: calc(100% - ${VariablesCSS.top} - 55px - 20px);
-        overflow: scroll;
-        -ms-overflow-style: none;
-        scrollbar-width: none;
-        &::-webkit-scrollbar {
-            display: none;
-        }
-    `
-
     // 라운드 (몇일차)
     const [gameRoundState] = useRecoilState(gameRound)
 
@@ -112,7 +91,7 @@ export default function Day({ statusType }: PropsType) {
                                 />
                             ) : (
                                 /* 직업보기모달 */
-                                <ViewJob onOpenModal={onToggleModal} />
+                                <ViewJob onOpenModal={onToggleModal} voteTime={false} />
                             )}
                         </ModalContainer>
 
@@ -140,3 +119,24 @@ export default function Day({ statusType }: PropsType) {
         </AppContainerCSS>
     )
 }
+
+const gameMessage = css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: calc(100% - ${VariablesCSS.top});
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 24px;
+    color: ${VariablesCSS.day};
+    animation: smoothshow 0.8s;
+`
+
+const middle = css`
+    height: calc(100% - ${VariablesCSS.top} - 55px - 20px);
+    overflow: scroll;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+        display: none;
+    }
+`

--- a/src/pages/FirstPage.tsx
+++ b/src/pages/FirstPage.tsx
@@ -6,80 +6,6 @@ import { Link } from 'react-router-dom'
 import BigButton from '../components/button/BigButton'
 
 export default function FirstPage() {
-    const container = css`
-        display: flex;
-        flex-direction: column;
-        justify-content: space-evenly;
-        height: calc(var(--vh, 1vh) * 100);
-
-        @keyframes slowshow {
-            0% {
-                opacity: 0;
-                transform: translateY(6px);
-            }
-            50% {
-                transform: translateY(0px);
-            }
-            100% {
-                opacity: 1;
-            }
-        }
-
-        & a:first-of-type {
-            display: block;
-            animation: slowshow 2s 0.5s backwards ease-out;
-        }
-        & a:nth-of-type(2) {
-            display: block;
-            margin-top: 10px;
-            animation: slowshow 2s 0.8s backwards ease-out;
-        }
-    `
-
-    const h1 = css`
-        margin: 0 auto;
-        font-family: 'LOTTERIACHAB', serif;
-        font-size: min(62px, 15vw);
-        font-weight: 400;
-        text-align: center;
-        word-break: keep-all;
-        color: ${VariablesCSS.light};
-        text-shadow: 0px 1px 8px rgba(0, 0, 0, 0.5);
-        animation: slowshow 1s 0.2s backwards ease-out;
-    `
-
-    const description = css`
-        font-family: 'DNFForgedBlade', serif;
-        font-size: 16px;
-        font-weight: 400;
-        color: ${VariablesCSS.light80};
-        text-shadow: 0 2px 2px rgb(0, 0, 0, 0.3);
-        line-height: 26px;
-
-        & > p:first-of-type,
-        & > p:nth-of-type(2) {
-            text-align: end;
-        }
-        & > p:nth-of-type(3),
-        & > p:nth-of-type(4) {
-            text-align: start;
-        }
-
-        & > p:first-of-type {
-            animation: slowshow 2s 2s backwards ease-out;
-        }
-        & > p:nth-of-type(2) {
-            animation: slowshow 2s 2.6s backwards ease-out;
-            margin-bottom: calc(var(--vh, 1vh) * 8);
-        }
-        & > p:nth-of-type(3) {
-            animation: slowshow 2s 3.4s backwards ease-out;
-        }
-        & > p:nth-of-type(4) {
-            animation: slowshow 2s 4s backwards ease-out;
-        }
-    `
-
     return (
         <AppContainerCSS>
             <div css={container}>
@@ -92,13 +18,87 @@ export default function FirstPage() {
                 </div>
                 <div>
                     <Link to="/create" style={{ textDecoration: 'none' }}>
-                        <BigButton vatiety="emphasis" use="createRoom" />
+                        <BigButton vatiety="emphasis" use="createRoom" ready={true} />
                     </Link>
                     <Link to={'/participate'} style={{ textDecoration: 'none' }}>
-                        <BigButton vatiety="soft" use="participate" />
+                        <BigButton vatiety="soft" use="participate" ready={true} />
                     </Link>
                 </div>
             </div>
         </AppContainerCSS>
     )
 }
+
+const container = css`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    height: calc(var(--vh, 1vh) * 100);
+
+    @keyframes slowshow {
+        0% {
+            opacity: 0;
+            transform: translateY(6px);
+        }
+        50% {
+            transform: translateY(0px);
+        }
+        100% {
+            opacity: 1;
+        }
+    }
+
+    & a:first-of-type {
+        display: block;
+        animation: slowshow 2s 0.5s backwards ease-out;
+    }
+    & a:nth-of-type(2) {
+        display: block;
+        margin-top: 10px;
+        animation: slowshow 2s 0.8s backwards ease-out;
+    }
+`
+
+const h1 = css`
+    margin: 0 auto;
+    font-family: 'LOTTERIACHAB', serif;
+    font-size: min(62px, 15vw);
+    font-weight: 400;
+    text-align: center;
+    word-break: keep-all;
+    color: ${VariablesCSS.light};
+    text-shadow: 0px 1px 8px rgba(0, 0, 0, 0.5);
+    animation: slowshow 1s 0.2s backwards ease-out;
+`
+
+const description = css`
+    font-family: 'DNFForgedBlade', serif;
+    font-size: 16px;
+    font-weight: 400;
+    color: ${VariablesCSS.light80};
+    text-shadow: 0 2px 2px rgb(0, 0, 0, 0.3);
+    line-height: 26px;
+
+    & > p:first-of-type,
+    & > p:nth-of-type(2) {
+        text-align: end;
+    }
+    & > p:nth-of-type(3),
+    & > p:nth-of-type(4) {
+        text-align: start;
+    }
+
+    & > p:first-of-type {
+        animation: slowshow 2s 2s backwards ease-out;
+    }
+    & > p:nth-of-type(2) {
+        animation: slowshow 2s 2.6s backwards ease-out;
+        margin-bottom: calc(var(--vh, 1vh) * 8);
+    }
+    & > p:nth-of-type(3) {
+        animation: slowshow 2s 3.4s backwards ease-out;
+    }
+    & > p:nth-of-type(4) {
+        animation: slowshow 2s 4s backwards ease-out;
+    }
+`

--- a/src/pages/InputCode.tsx
+++ b/src/pages/InputCode.tsx
@@ -11,42 +11,6 @@ import { notifyUseToast } from '../components/toast/NotifyToast'
 import { getValidRoomCode } from '../axios/http'
 
 export default function ParticipateRoom() {
-    const middle = css`
-        display: flex;
-        height: calc((var(--vh, 1vh) * 100) - ${VariablesCSS.top});
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        gap: 10%;
-    `
-
-    const codeinput = css`
-        box-sizing: border-box;
-        width: 270px;
-        height: 75px;
-        padding: 22px 42px;
-        border-radius: 15px;
-        border: 3px solid ${VariablesCSS.light};
-        background-color: ${VariablesCSS.light20};
-        color: ${VariablesCSS.light};
-        font-size: ${VariablesCSS.default};
-        font-family: 'Cafe24Ssurround', sans-serif;
-        text-align: center;
-
-        &::-webkit-outer-spin-button,
-        &::-webkit-inner-spin-button {
-            -webkit-appearance: none;
-            margin: 0;
-        }
-        input[type='number'] {
-            -moz-appearance: textfield;
-        }
-
-        &:focus {
-            outline: 3px solid ${VariablesCSS.light};
-        }
-    `
-
     /* 코드 자동입력 */
     const [searchParams] = useSearchParams()
     const codeParams = !searchParams.get('code') ? '' : searchParams.get('code')
@@ -93,13 +57,7 @@ export default function ParticipateRoom() {
                         autoFocus
                         autoComplete="off"
                     />
-                    <button
-                        type="submit"
-                        css={css`
-                            display: block;
-                            width: 100%;
-                        `}
-                    >
+                    <button type="submit" css={buttonContainer}>
                         <BigButton vatiety="soft" use="participate" ready={isValidCode()} />
                     </button>
                 </form>
@@ -108,3 +66,44 @@ export default function ParticipateRoom() {
         </AppContainerCSS>
     )
 }
+
+const middle = css`
+    display: flex;
+    height: calc((var(--vh, 1vh) * 100) - ${VariablesCSS.top});
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 10%;
+`
+
+const codeinput = css`
+    box-sizing: border-box;
+    width: 270px;
+    height: 75px;
+    padding: 22px 42px;
+    border-radius: 15px;
+    border: 3px solid ${VariablesCSS.light};
+    background-color: ${VariablesCSS.light20};
+    color: ${VariablesCSS.light};
+    font-size: ${VariablesCSS.default};
+    font-family: 'Cafe24Ssurround', sans-serif;
+    text-align: center;
+
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+    }
+    input[type='number'] {
+        -moz-appearance: textfield;
+    }
+
+    &:focus {
+        outline: 3px solid ${VariablesCSS.light};
+    }
+`
+
+const buttonContainer = css`
+    display: block;
+    width: 100%;
+`

--- a/src/pages/InputName.tsx
+++ b/src/pages/InputName.tsx
@@ -11,33 +11,6 @@ import { Toaster } from 'react-hot-toast'
 import { notifyUseToast } from '../components/toast/NotifyToast'
 
 export default function InputName() {
-    const middle = css`
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        height: calc((var(--vh, 1vh) * 100) - ${VariablesCSS.top} - ${VariablesCSS.bottombutton});
-    `
-
-    const nameCss = css`
-        box-sizing: border-box;
-        width: 90%;
-        max-width: 316px;
-        height: 75px;
-        padding: 22px 10px;
-        border-radius: 15px;
-        border: 3px solid ${VariablesCSS.light};
-        background-color: ${VariablesCSS.light20};
-        color: ${VariablesCSS.light};
-        font-size: ${VariablesCSS.default};
-        font-family: 'Cafe24Ssurround', sans-serif;
-        text-align: center;
-        word-break: break-all;
-
-        &:focus {
-            outline: 3px solid ${VariablesCSS.light};
-        }
-    `
-
     const [name, setName] = useState('')
     const onName = (e: React.ChangeEvent<HTMLInputElement>) => {
         if (e.target.value.length <= 10) {
@@ -89,7 +62,11 @@ export default function InputName() {
                         />
                     </div>
                     <button type="submit">
-                        <BottomButton use="complete" ready={canParticipateRoom()} />
+                        <BottomButton
+                            use="complete"
+                            daynight="night"
+                            ready={canParticipateRoom()}
+                        />
                     </button>
                 </form>
                 <Toaster containerStyle={{ bottom: `calc(${VariablesCSS.bottombutton} + 4px)` }} />
@@ -97,3 +74,30 @@ export default function InputName() {
         </AppContainerCSS>
     )
 }
+
+const middle = () => css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: calc((var(--vh, 1vh) * 100) - ${VariablesCSS.top} - ${VariablesCSS.bottombutton});
+`
+
+const nameCss = () => css`
+    box-sizing: border-box;
+    width: 90%;
+    max-width: 316px;
+    height: 75px;
+    padding: 22px 10px;
+    border-radius: 15px;
+    border: 3px solid ${VariablesCSS.light};
+    background-color: ${VariablesCSS.light20};
+    color: ${VariablesCSS.light};
+    font-size: ${VariablesCSS.default};
+    font-family: 'Cafe24Ssurround', sans-serif;
+    text-align: center;
+    word-break: break-all;
+
+    &:focus {
+        outline: 3px solid ${VariablesCSS.light};
+    }
+`

--- a/src/pages/Night.tsx
+++ b/src/pages/Night.tsx
@@ -16,28 +16,8 @@ import { myJobState, roomInfoState } from '../recoil/roominfo/atom'
 type PropsType = {
     statusType: Status
 }
-export const middle = css`
-    height: calc(100% - ${VariablesCSS.top});
-    overflow: scroll;
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-    &::-webkit-scrollbar {
-        display: none;
-    }
-`
 
 export default function Night({ statusType }: PropsType) {
-    const gameMessage = css`
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        height: calc(100% - ${VariablesCSS.top});
-        font-family: 'Cafe24Ssurround', sans-serif;
-        font-size: 24px;
-        color: ${VariablesCSS.light};
-        animation: smoothshow 0.8s;
-    `
-
     const [roomInfo] = useRecoilState(roomInfoState)
     const [myJob] = useRecoilState(myJobState)
 
@@ -85,3 +65,24 @@ export default function Night({ statusType }: PropsType) {
         </AppContainerCSS>
     )
 }
+
+export const middle = () => css`
+    height: calc(100% - ${VariablesCSS.top});
+    overflow: scroll;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+        display: none;
+    }
+`
+
+const gameMessage = () => css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: calc(100% - ${VariablesCSS.top});
+    font-family: 'Cafe24Ssurround', sans-serif;
+    font-size: 24px;
+    color: ${VariablesCSS.light};
+    animation: smoothshow 0.8s;
+`

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -20,77 +20,14 @@ export default function Result() {
         return <></>
     }
 
-    const middle = css`
-        display: flex;
-        flex-direction: column;
-        justify-content: start;
-        align-items: center;
-        height: calc((var(--vh, 1vh) * 100) - ${VariablesCSS.top} - ${VariablesCSS.bottombutton});
-        overflow: scroll;
-        -ms-overflow-style: none;
-        scrollbar-width: none;
-        &::-webkit-scrollbar {
-            display: none;
-        }
-    `
-
-    const winner = css`
-        box-sizing: border-box;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        gap: 26px;
-        width: 92%;
-        margin-top: 30px;
-        padding: 30px;
-        ${roomsResults.winnerJob === 'MAFIA'
-            ? `background-color: rgba(217, 217, 217, 0.2);`
-            : ` background-color: rgba(255, 255, 255, 0.3);`}
-
-        border-radius: 15px;
-    `
-
-    const description = css`
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        gap: 10px;
-        ${roomsResults.winnerJob === 'MAFIA'
-            ? `color: ${VariablesCSS.light};`
-            : `color: ${VariablesCSS.day};`}
-
-        font-family: "Cafe24Ssurround", sans-serif;
-        font-size: ${VariablesCSS.default};
-        word-break: keep-all;
-    `
-
-    const winnerGroup = css`
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: center;
-        align-items: center;
-        gap: 10px;
-    `
-
-    const loserGroup = css`
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        flex-wrap: wrap;
-        gap: 10px;
-        margin-top: 50px;
-        margin-bottom: 50px;
-    `
-
     return (
         <AppContainerCSS background={roomsResults.winnerJob === 'MAFIA' ? 'night' : 'day'}>
             <div>
                 <TopResult daynight={roomsResults.winnerJob === 'MAFIA' ? 'night' : 'day'} />
 
                 <div css={middle}>
-                    <div css={winner}>
-                        <div css={description}>
+                    <div css={winner(roomsResults)}>
+                        <div css={description(roomsResults)}>
                             {roomsResults.winnerJob === 'MAFIA' ? (
                                 <svg
                                     width="41"
@@ -171,3 +108,66 @@ export default function Result() {
         </AppContainerCSS>
     )
 }
+
+const middle = () => css`
+    display: flex;
+    flex-direction: column;
+    justify-content: start;
+    align-items: center;
+    height: calc((var(--vh, 1vh) * 100) - ${VariablesCSS.top} - ${VariablesCSS.bottombutton});
+    overflow: scroll;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+        display: none;
+    }
+`
+
+const winner = (roomsResults: RoomsResults) => css`
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 26px;
+    width: 92%;
+    margin-top: 30px;
+    padding: 30px;
+    ${roomsResults.winnerJob === 'MAFIA'
+        ? `background-color: rgba(217, 217, 217, 0.2);`
+        : ` background-color: rgba(255, 255, 255, 0.3);`}
+
+    border-radius: 15px;
+`
+
+const description = (roomsResults: RoomsResults) => css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    ${roomsResults.winnerJob === 'MAFIA'
+        ? `color: ${VariablesCSS.light};`
+        : `color: ${VariablesCSS.day};`}
+
+    font-family: "Cafe24Ssurround", sans-serif;
+    font-size: ${VariablesCSS.default};
+    word-break: keep-all;
+`
+
+const winnerGroup = () => css`
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+`
+
+const loserGroup = () => css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 50px;
+    margin-bottom: 50px;
+`

--- a/src/pages/WaitingRoom.tsx
+++ b/src/pages/WaitingRoom.tsx
@@ -15,135 +15,7 @@ import { Player } from '../type'
 import { Loading } from '../components/etc/Loading'
 
 export default function WaitingRoom() {
-    /* css */
-    const middle = css`
-        height: calc(
-            (var(--vh, 1vh) * 100) - ${VariablesCSS.top} - ${VariablesCSS.bigbutton} -
-                ${VariablesCSS.margin}
-        );
-        overflow: scroll;
-        -ms-overflow-style: none;
-        scrollbar-width: none;
-        &::-webkit-scrollbar {
-            display: none;
-        }
-    `
-    const textGroup = css`
-        margin-top: 16px;
-        margin-bottom: 32px;
-        font-family: 'Cafe24Ssurround', sans-serif;
-        color: ${VariablesCSS.light};
-        text-align: center;
-    `
-
-    const subTitle = css`
-        font-size: 24px;
-    `
-
-    const number = css`
-        font-size: 20px;
-    `
-
-    const bottom = css`
-        position: absolute;
-        bottom: 0;
-        width: 100%;
-        margin-bottom: ${VariablesCSS.margin};
-    `
-
     const [openAnimation, setOpenAnimation] = useState(false)
-
-    const inviteModalContainer = css`
-        ${openAnimation && 'animation: smoothshow 0.5s backwards;'}
-        ${openAnimation || 'animation: smoothhide 0.5s backwards;'}
-    `
-
-    const dimmed = css`
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100vw;
-        height: calc(var(--vh, 1vh) * 100);
-        margin-left: -${VariablesCSS.margin};
-        margin-right: -${VariablesCSS.margin};
-        background-color: rgba(0, 0, 0, 0.7);
-    `
-
-    const modalInner = css`
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        box-sizing: border-box;
-        width: 95%;
-        height: 240px;
-        background: linear-gradient(118.95deg, #dfcfeb 0%, #c9abca 100%);
-        border: 5px solid #ffffff;
-        border-radius: 15px;
-        transform: translate(-50%, -50%);
-        ${openAnimation && 'animation: smoothupNomargin 0.5s backwards;'}
-        ${openAnimation || 'animation: smoothdownNomargin 0.5s backwards;'}
-    `
-
-    const modalTitle = css`
-        display: flex;
-        justify-content: center;
-        margin-top: 16px;
-
-        font-family: 'WAGURITTF', serif;
-        font-size: ${VariablesCSS.title};
-        color: ${VariablesCSS.night};
-    `
-
-    const close = css`
-        position: absolute;
-        top: 7px;
-        right: 10px;
-        cursor: pointer;
-    `
-
-    const inviteShareLinkCss = css`
-        display: flex;
-        gap: 10px;
-        margin: 35px auto 26px;
-        padding: 17px 30px;
-        font-family: 'Cafe24Ssurround', serif;
-        font-size: 18px;
-        color: ${VariablesCSS.night};
-        border-radius: 15px;
-        background-color: rgba(240, 238, 243, 0.5);
-        box-shadow: inset -2px -2px 4px rgba(0, 0, 0, 0.25);
-        transition-property: box-shadow transform;
-        transition-duration: 0.1s;
-        cursor: pointer;
-
-        &:active {
-            box-shadow: inset -1px -1px 1px rgba(0, 0, 0, 0.25);
-            transform: translate(0.5px, 1px);
-        }
-    `
-
-    const inviteCodeContainer = css`
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        gap: 32px;
-        font-family: 'Cafe24Ssurround', serif;
-        cursor: pointer;
-
-        &:active {
-            transform: translate(0.5px, 1px);
-        }
-    `
-
-    const inviteCodeDescription = css`
-        color: rgba(77, 61, 77, 0.8);
-        font-size: 18px;
-    `
-
-    const inviteCodeCss = css`
-        color: ${VariablesCSS.night};
-        font-size: 20px;
-    `
 
     /* 참가목록 받아오기 */
     const [players, setPlayers] = useState<Player[]>([])
@@ -242,9 +114,9 @@ export default function WaitingRoom() {
                     </div>
 
                     {openModal ? (
-                        <div css={inviteModalContainer}>
+                        <div css={inviteModalContainer(openAnimation)}>
                             <div css={dimmed}></div>
-                            <div css={modalInner}>
+                            <div css={modalInner(openAnimation)}>
                                 <div css={modalTitle}>
                                     <p>초대하기</p>
                                     <button css={close} onClick={onClose}>
@@ -294,3 +166,131 @@ export default function WaitingRoom() {
         </AppContainerCSS>
     )
 }
+
+/* css */
+const middle = css`
+    height: calc(
+        (var(--vh, 1vh) * 100) - ${VariablesCSS.top} - ${VariablesCSS.bigbutton} -
+            ${VariablesCSS.margin}
+    );
+    overflow: scroll;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+        display: none;
+    }
+`
+const textGroup = css`
+    margin-top: 16px;
+    margin-bottom: 32px;
+    font-family: 'Cafe24Ssurround', sans-serif;
+    color: ${VariablesCSS.light};
+    text-align: center;
+`
+
+const subTitle = css`
+    font-size: 24px;
+`
+
+const number = css`
+    font-size: 20px;
+`
+
+const bottom = css`
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    margin-bottom: ${VariablesCSS.margin};
+`
+
+const inviteModalContainer = (openAnimation: boolean) => css`
+    ${openAnimation && 'animation: smoothshow 0.5s backwards;'}
+    ${openAnimation || 'animation: smoothhide 0.5s backwards;'}
+`
+
+const dimmed = css`
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: calc(var(--vh, 1vh) * 100);
+    margin-left: -${VariablesCSS.margin};
+    margin-right: -${VariablesCSS.margin};
+    background-color: rgba(0, 0, 0, 0.7);
+`
+
+const modalInner = (openAnimation: boolean) => css`
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    box-sizing: border-box;
+    width: 95%;
+    height: 240px;
+    background: linear-gradient(118.95deg, #dfcfeb 0%, #c9abca 100%);
+    border: 5px solid #ffffff;
+    border-radius: 15px;
+    transform: translate(-50%, -50%);
+    ${openAnimation && 'animation: smoothupNomargin 0.5s backwards;'}
+    ${openAnimation || 'animation: smoothdownNomargin 0.5s backwards;'}
+`
+
+const modalTitle = css`
+    display: flex;
+    justify-content: center;
+    margin-top: 16px;
+
+    font-family: 'WAGURITTF', serif;
+    font-size: ${VariablesCSS.title};
+    color: ${VariablesCSS.night};
+`
+
+const close = css`
+    position: absolute;
+    top: 7px;
+    right: 10px;
+    cursor: pointer;
+`
+
+const inviteShareLinkCss = css`
+    display: flex;
+    gap: 10px;
+    margin: 35px auto 26px;
+    padding: 17px 30px;
+    font-family: 'Cafe24Ssurround', serif;
+    font-size: 18px;
+    color: ${VariablesCSS.night};
+    border-radius: 15px;
+    background-color: rgba(240, 238, 243, 0.5);
+    box-shadow: inset -2px -2px 4px rgba(0, 0, 0, 0.25);
+    transition-property: box-shadow transform;
+    transition-duration: 0.1s;
+    cursor: pointer;
+
+    &:active {
+        box-shadow: inset -1px -1px 1px rgba(0, 0, 0, 0.25);
+        transform: translate(0.5px, 1px);
+    }
+`
+
+const inviteCodeContainer = css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 32px;
+    font-family: 'Cafe24Ssurround', serif;
+    cursor: pointer;
+
+    &:active {
+        transform: translate(0.5px, 1px);
+    }
+`
+
+const inviteCodeDescription = css`
+    color: rgba(77, 61, 77, 0.8);
+    font-size: 18px;
+`
+
+const inviteCodeCss = css`
+    color: ${VariablesCSS.night};
+    font-size: 20px;
+`


### PR DESCRIPTION
1. 컴포넌트밖으로 빼기
- 컴포넌트에서 쓰는 props 를 그대로 넘겨서 타입 재활용했습니다.
- css에 props를 그대로 넘기기 위해 구조분해할당으로 props를 받던 형태 -> props 받기

예시
```
const container = (props: PropsType) => css`
    display: flex;
    justify-content: space-between;
    align-items: center;
    height: ${VariablesCSS.top};
    ${props.daynight === 'night'
        ? `border-bottom: 1px solid ${VariablesCSS.light50};`
        : `border-bottom: 1px solid ${VariablesCSS.day};`}
    font-size: ${VariablesCSS.title};
    ${props.daynight === 'night' ? `color: ${VariablesCSS.light};` : ` color: ${VariablesCSS.day};`}
    & p {
        margin-top: 2px;
        display: block;
    }
```

close #87 