### PR TITLE
feat: 방만들기 실패 시 이유를 토스트로 띄워주기

### DIFF
--- a/src/components/toast/NotifyToast.ts
+++ b/src/components/toast/NotifyToast.ts
@@ -2,8 +2,8 @@ import toast from 'react-hot-toast';
 
 import { VariablesCSS } from '../../styles/VariablesCSS';
 
-export const notifyUseToast = (message: string, whereUse: 'ENTER' | 'INVITE') => {
-  if (whereUse === 'ENTER') {
+export const notifyUseToast = (message: string, whereUse: 'LOBBY' | 'INVITE') => {
+  if (whereUse === 'LOBBY') {
     return toast(message, {
       duration: 3000,
       position: 'bottom-center',

--- a/src/pages/CreateRoom.tsx
+++ b/src/pages/CreateRoom.tsx
@@ -45,30 +45,34 @@ export function CreateRoom() {
     }
   };
 
-  const canCreateRoom = (): { result: boolean; message: string } => {
+  interface RoomCreationResult {
+    result: boolean;
+    message: string;
+  }
+
+  const canCreateRoom = (): RoomCreationResult => {
     // 총 인원이 게임 최소 요건을 충족하는지 확인
     const isTotalJobCountValid = jobCount.total >= MIN_TOTAL;
-    if (!isTotalJobCountValid) {
-      return { result: false, message: `총인원은 ${MIN_TOTAL}명 이상이어야 합니다.` };
-    }
 
     // 마피아 역할 수가 최소 마피아 수 요구 사항을 충족하는지 확인
     const isMafiaCountValid = jobCount.mafia >= MIN_MAFIA;
-    if (!isMafiaCountValid) {
-      return { result: false, message: `마피아가 최소 ${MIN_MAFIA}명 이상이어야 합니다.` };
-    }
 
     // 시민팀이 더 많은지 확인 = 총 인원이 마피아 팀의 2배보다 큰지 확인
     const isMafiaRatioValid = jobCount.total > jobCount.mafia * 2;
-    if (!isMafiaRatioValid) {
-      return { result: false, message: `시민팀이 더 많아야 합니다.` };
-    }
 
     // 총 인원이 직업수(마피아, 의사, 경찰) 역할 수의 합 이상인지 확인
     const isRolesCountSufficient =
       jobCount.total >= jobCount.mafia + jobCount.doctor + jobCount.police;
-    if (!isRolesCountSufficient) {
-      return { result: false, message: `총인원이 직업 수 이상이어야 합니다.` };
+
+    switch (true) {
+      case !isTotalJobCountValid:
+        return { result: false, message: `총인원은 ${MIN_TOTAL}명 이상이어야 합니다.` };
+      case !isMafiaCountValid:
+        return { result: false, message: `마피아가 최소 ${MIN_MAFIA}명 이상이어야 합니다.` };
+      case !isMafiaRatioValid:
+        return { result: false, message: `시민팀이 더 많아야 합니다.` };
+      case !isRolesCountSufficient:
+        return { result: false, message: `총인원이 직업 수 이상이어야 합니다.` };
     }
 
     // 게임시작가능

--- a/src/pages/CreateRoom.tsx
+++ b/src/pages/CreateRoom.tsx
@@ -49,13 +49,13 @@ export function CreateRoom() {
     // 총 인원이 게임 최소 요건을 충족하는지 확인
     const isTotalJobCountValid = jobCount.total >= MIN_TOTAL;
     if (!isTotalJobCountValid) {
-      return { result: false, message: `총인원은 ${MIN_TOTAL}명 이상이여야 합니다.` };
+      return { result: false, message: `총인원은 ${MIN_TOTAL}명 이상이어야 합니다.` };
     }
 
     // 마피아 역할 수가 최소 마피아 수 요구 사항을 충족하는지 확인
     const isMafiaCountValid = jobCount.mafia >= MIN_MAFIA;
     if (!isMafiaCountValid) {
-      return { result: false, message: `마피아가 최소${MIN_MAFIA}명 이상이여야 합니다.` };
+      return { result: false, message: `마피아가 최소 ${MIN_MAFIA}명 이상이어야 합니다.` };
     }
 
     // 시민팀이 더 많은지 확인 = 총 인원이 마피아 팀의 2배보다 큰지 확인
@@ -68,7 +68,7 @@ export function CreateRoom() {
     const isRolesCountSufficient =
       jobCount.total >= jobCount.mafia + jobCount.doctor + jobCount.police;
     if (!isRolesCountSufficient) {
-      return { result: false, message: `총인원이 직업수 이상이어야 합니다.` };
+      return { result: false, message: `총인원이 직업 수 이상이어야 합니다.` };
     }
 
     // 게임시작가능

--- a/src/pages/InputCode.tsx
+++ b/src/pages/InputCode.tsx
@@ -37,7 +37,7 @@ export default function ParticipateRoom() {
     if (isValidCode()) {
       const roomCodeExistsResponse = await getValidRoomCode(code);
       if (!roomCodeExistsResponse.exist) {
-        notifyUseToast('해당하는 방이 존재하지 않습니다.', 'ENTER');
+        notifyUseToast('해당하는 방이 존재하지 않습니다.', 'LOBBY');
         return;
       }
       navigate(`/name?code=${code}`);

--- a/src/pages/InputName.tsx
+++ b/src/pages/InputName.tsx
@@ -40,7 +40,7 @@ export default function InputName() {
       } catch (error: any) {
         console.log(error);
 
-        notifyUseToast(error.response.data.message, 'ENTER');
+        notifyUseToast(error.response.data.message, 'LOBBY');
       }
     }
   };


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/057db1c7-5b06-4d7c-ad55-5a87874b03aa)

#### 방만들기 실패시 이유를 토스트로 띄워주는 기능을 완성했습니다.
1. 세부적인 디자인 이야기는 없어서 제 임의로 기존 opaticy 20%는 유지하고 클릭시 토스트 띄웠습니다.

2. 기존 canCreateRoom 함수의 반환값을 객체로 바꾸어서 구현했는데 어떠신가요?

3. 고민이 있다면, 이제는 변수가 오히려 가독성을 떨어뜨리는 느낌이라 isMafiaRaiovalid같은 변수를 없애면 짧아져서 좋을 것 같더라구요. 의견이 궁금합니다.

```
const canCreateRoom = (): { result: boolean; message: string } => {
    // 총 인원이 게임 최소 요건을 충족하는지 확인
    const isTotalJobCountValid = jobCount.total >= MIN_TOTAL;
    if (!isTotalJobCountValid) {
      return { result: false, message: `총인원은 ${MIN_TOTAL}명 이상이여야 합니다.` };
    }

    // 마피아 역할 수가 최소 마피아 수 요구 사항을 충족하는지 확인
    const isMafiaCountValid = jobCount.mafia >= MIN_MAFIA;
    if (!isMafiaCountValid) {
      return { result: false, message: `마피아가 최소${MIN_MAFIA}명 이상이여야 합니다.` };
    }

    // 시민팀이 더 많은지 확인 = 총 인원이 마피아 팀의 2배보다 큰지 확인
    const isMafiaRatioValid = jobCount.total > jobCount.mafia * 2;
    if (!isMafiaRatioValid) {
      return { result: false, message: `시민팀이 더 많아야 합니다.` };
    }

    // 총 인원이 직업수(마피아, 의사, 경찰) 역할 수의 합 이상인지 확인
    const isRolesCountSufficient =
      jobCount.total >= jobCount.mafia + jobCount.doctor + jobCount.police;
    if (!isRolesCountSufficient) {
      return { result: false, message: `총인원이 직업수 이상이어야 합니다.` };
    }

    // 게임시작가능
    return { result: true, message: '게임 시작가능합니다.' };
  };
```


close #97 
