### PR TITLE
feat: localStroage에 있는 auth가 유효하면 재접속할 수 있도록 comfirm 띄우기

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -7,6 +7,7 @@ import Game from './pages/Game';
 import InputCode from './pages/InputCode';
 import InputName from './pages/InputName';
 import NotFound from './pages/NotFound';
+import CheckAuth from './routers/CheckAuth';
 import CheckInAppBrowser from './routers/CheckInAppBrowser';
 
 interface RouteElement {
@@ -19,27 +20,39 @@ interface RouteElement {
 const routes: RouteElement[] = [
   {
     path: '/',
-    element: <FirstPage />,
+    element: (
+      <CheckAuth>
+        <FirstPage />
+      </CheckAuth>
+    ),
   },
   {
     path: 'create',
     element: (
-      <CheckInAppBrowser>
-        <CreateRoom />
-      </CheckInAppBrowser>
+      <CheckAuth>
+        <CheckInAppBrowser>
+          <CreateRoom />
+        </CheckInAppBrowser>
+      </CheckAuth>
     ),
   },
   {
     path: '/participate',
     element: (
-      <CheckInAppBrowser>
-        <InputCode />
-      </CheckInAppBrowser>
+      <CheckAuth>
+        <CheckInAppBrowser>
+          <InputCode />
+        </CheckInAppBrowser>
+      </CheckAuth>
     ),
   },
   {
     path: '/name',
-    element: <InputName />,
+    element: (
+      <CheckAuth>
+        <InputName />
+      </CheckAuth>
+    ),
   },
   {
     path: '/game',

--- a/src/axios/http.ts
+++ b/src/axios/http.ts
@@ -92,7 +92,7 @@ export const getRoomsResults = () => {
 };
 
 export const existGame = () => {
-  return http.get<GameExist>('/games/exist');
+  return http.get<GameExist>('/games/valid');
 };
 
 export const getChats = () => {

--- a/src/axios/http.ts
+++ b/src/axios/http.ts
@@ -4,6 +4,7 @@ import {
   Chat,
   ChatRequest,
   DeadResult,
+  GameExist,
   GameInfo,
   GamesResults,
   MafiaVoteResult,
@@ -89,6 +90,11 @@ export const startGame = async () => {
 export const getRoomsResults = () => {
   return http.get<GamesResults>('/games/result');
 };
+
+export const existGame = () => {
+  return http.get<GameExist>('/games/exist');
+};
+
 export const getChats = () => {
   return http.get<Chat[]>(`/chat`);
 };

--- a/src/pages/InputName.tsx
+++ b/src/pages/InputName.tsx
@@ -12,6 +12,7 @@ import TopEnter from '../components/top/TopEnter';
 import { VariablesCSS } from '../styles/VariablesCSS';
 
 export default function InputName() {
+  const navigate = useNavigate();
   const [name, setName] = useState('');
   const onName = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.value.length <= 10) {
@@ -27,7 +28,6 @@ export default function InputName() {
   const [searchParams] = useSearchParams();
   const code = searchParams.get('code') as string;
 
-  const navigate = useNavigate();
   const goWaitingRoom = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 

--- a/src/routers/CheckAuth.tsx
+++ b/src/routers/CheckAuth.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { existGame } from '../axios/http';
+
+interface propsType {
+  children: React.ReactNode;
+}
+
+export default function CheckAuth({ children }: propsType) {
+  const navigate = useNavigate();
+  useEffect(() => {
+    (async () => {
+      const isExist = await existGame();
+      if (isExist) {
+        if (confirm('이미 참가중인 방이 있습니다. 재접속 하시겠습니까?')) {
+          navigate('/game');
+        }
+      }
+    })();
+  }, []);
+
+  return <>{children}</>;
+}

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -107,5 +107,5 @@ export interface GamesResults {
 }
 
 export interface GameExist {
-  exist: boolean;
+  valid: boolean;
 }

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -105,3 +105,7 @@ export interface GamesResults {
   winner: Player[];
   loser: Player[];
 }
+
+export interface GameExist {
+  exist: boolean;
+}


### PR DESCRIPTION
CheckAuth 컴포넌트를 만들어서 라우터에서 감싸주었음. => 한번만 확인 & 중복 코드 없앰

1. auth가 유효한지 api통해 확인
2. 유효하면 confirm으로 재접속 할건지 물어봄
3. 재접속한다고 하면 /game으로 보냄


(로비화면) 첫화면, 방만들기, 초대하기, 이름입력 에서 확인함

close #118
