### PR TITLE
fix: auth valid를 검사하여 true일때만 confirm이 뜨도록 수정

### DIFF
--- a/src/routers/CheckAuth.tsx
+++ b/src/routers/CheckAuth.tsx
@@ -12,7 +12,7 @@ export default function CheckAuth({ children }: propsType) {
   useEffect(() => {
     (async () => {
       const isExist = await existGame();
-      if (isExist) {
+      if (isExist.valid) {
         if (confirm('이미 참가중인 방이 있습니다. 재접속 하시겠습니까?')) {
           navigate('/game');
         }


### PR DESCRIPTION
api결과의 valid를 검사해야하는데, response 자체를 비교하고 있었음
valid를 검사하는 것으로 수정

close #124