### PR TITLE
방 상태를 SSE로 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.11.4",
         "@tanstack/react-query": "^5.32.0",
         "axios": "^1.6.8",
+        "event-source-polyfill": "^1.0.31",
         "react": "^18.2.0",
         "react-cookie": "^7.1.4",
         "react-dom": "^18.2.0",
@@ -19,6 +20,7 @@
         "recoil": "^0.7.7"
       },
       "devDependencies": {
+        "@types/event-source-polyfill": "^1.0.5",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "@typescript-eslint/eslint-plugin": "^7.2.0",
@@ -1300,6 +1302,12 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
+    "node_modules/@types/event-source-polyfill": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/event-source-polyfill/-/event-source-polyfill-1.0.5.tgz",
+      "integrity": "sha512-iaiDuDI2aIFft7XkcwMzDWLqo7LVDixd2sR6B4wxJut9xcp/Ev9bO4EFg4rm6S9QxATLBj5OPxdeocgmhjwKaw==",
+      "dev": true
+    },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
@@ -2142,6 +2150,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/event-source-polyfill": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
+      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@emotion/react": "^11.11.4",
     "@tanstack/react-query": "^5.32.0",
     "axios": "^1.6.8",
+    "event-source-polyfill": "^1.0.31",
     "react": "^18.2.0",
     "react-cookie": "^7.1.4",
     "react-dom": "^18.2.0",
@@ -23,6 +24,7 @@
     "recoil": "^0.7.7"
   },
   "devDependencies": {
+    "@types/event-source-polyfill": "^1.0.5",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@typescript-eslint/eslint-plugin": "^7.2.0",

--- a/src/axios/http.ts
+++ b/src/axios/http.ts
@@ -7,13 +7,13 @@ import {
   GameExist,
   GameInfo,
   GamesResults,
+  GameStatus,
   MafiaVoteResult,
   MyJobResponse,
   ParticipateRequest,
   ParticipateResponse,
   RoomCodeExistsResponse,
   RoomResponse,
-  RoomsStatus,
   SkillRequest,
   SkillResponse,
   VoteRequest,
@@ -54,19 +54,8 @@ export const useChatsQuery = () => {
   };
 };
 
-export const useGamesStatusQuery = () => {
-  const { data: gamesStatus, ...rest } = useSuspenseQuery({
-    queryKey: ['games', 'status', localStorage.getItem('auth')],
-    queryFn: () => getRoomsStatus(),
-    refetchInterval: 500,
-    staleTime: 500,
-  });
-
-  return { gamesStatus, ...rest };
-};
-
 export const getRoomsStatus = () => {
-  return http.get<RoomsStatus>('/games/status');
+  return http.get<GameStatus>('/games/status');
 };
 
 export const useGamesInfoQuery = () => {

--- a/src/axios/instances.ts
+++ b/src/axios/instances.ts
@@ -1,7 +1,9 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 
+export const BASE_URL = 'https://mafia-together.com/api';
+
 export const axiosInstance = axios.create({
-  baseURL: 'https://mafia-together.com/api',
+  baseURL: BASE_URL,
   withCredentials: true,
   timeout: 5000,
 });

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -16,7 +16,7 @@ export default function Result() {
       const roomsResults = await getRoomsResults();
       setRoomsResults(roomsResults);
     })();
-  }, [roomsResults]);
+  }, []);
   if (!roomsResults) {
     return <></>;
   }

--- a/src/routers/CheckInAppBrowser.tsx
+++ b/src/routers/CheckInAppBrowser.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import { Toaster } from 'react-hot-toast';
 
 import { notifyUseToast } from '../components/toast/NotifyToast';
 
@@ -17,10 +16,5 @@ export default function CheckInAppBrowser({ children }: propsType) {
     }
   }, []);
 
-  return (
-    <>
-      <Toaster />
-      {children}
-    </>
-  );
+  return <>{children}</>;
 }

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -14,7 +14,7 @@ export type Color = 'day' | 'night' | 'dark' | 'light' | 'kill' | 'safe' | 'dead
 export type Dead = string | null;
 export type ExcludeSpecialJob = 'MAFIA' | 'CITIZEN';
 
-export interface RoomsStatus {
+export interface GameStatus {
   statusType: Status;
 }
 


### PR DESCRIPTION
1. 헤더에 auth를 넣어야 하므로 EventSourcePolyfill을 사용함
2. 구독해주었음
```   
eventSource.current = new EventSource(`${BASE_URL}/games/subscribe`, {
      headers: { Authorization: `Basic ${auth}` },
      heartbeatTimeout: 1000 * 60 * 60 * 12,
      withCredentials: true,
    }); 
```
3. 이벤트이름이 gameStatus 일 때 받음
4. 게임상태를 useState 로 변경하였음. 그리고 sse로 이벤트를 받으면 변경
5. 게임상태 polling하는 query 코드 삭제


close #126